### PR TITLE
Simplify map-making tutorial for 90-minute delivery

### DIFF
--- a/docs/tutorials/publichealth/gis.md
+++ b/docs/tutorials/publichealth/gis.md
@@ -2,8 +2,14 @@
 
 <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.
 
-!!! Info "Setup"
+!!! Example "What you'll build (90 min)"
+    A scrolling Leaflet story-map of the 1850 London cholera outbreak,
+    served locally at http://localhost:51234. By minute 60 you should
+    see the Broad Street pump and the death-density choropleth on screen.
 
+??? Info "Setup (click to expand if you haven't installed tools yet)"
+
+    **Minimum path for this lab:** VS Code + Cline extension + the [Filesystem MCP server](https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem). Everything else below is alternative or optional.
 
     !!! Success "Desktop LLM Apps"
         
@@ -21,7 +27,6 @@
 
             [:material-infinity: AnythingLLM https://anythingllm.com/desktop](https://anythingllm.com/desktop){target=_blank} 
 
-    
     !!! Success "Integrated Development Environment (IDE) Desktops"
     
         !!! Success ":material-microsoft-visual-studio-code: VS Code"
@@ -34,19 +39,15 @@
 
             [:simple-posit: https://positron.posit.co/](https://positron.posit.co/){target=_blank} 
 
-    
         !!! Success "API Access"
 
             [:simple-claude: https://console.anthropic.com/](https://console.anthropic.com/){target=_blank}
 
-    
     **Cline (:material-microsoft-visual-studio-code: VS Code Extension)** [:material-robot: https://cline.bot/](https://cline.bot/){target=_blank}
 
     **Optional: :simple-qgis: QGIS** [https://qgis.org/download/](https://qgis.org/download/){target=_blank}
 
-    **:simple-qgis: QGISMCP**
-
-    [:material-github: https://github.com/jjsantos01/qgis_mcp](https://github.com/jjsantos01/qgis_mcp){target=_blank}
+    **:simple-qgis: QGISMCP** [:material-github: https://github.com/jjsantos01/qgis_mcp](https://github.com/jjsantos01/qgis_mcp){target=_blank}
 
 ## Prompt Engineering & Vibe Coding
 
@@ -59,18 +60,35 @@
 |---|-------------|-------|
 |   | Frontier-class LLM access (API or Desktop) | Claude 4, GPT-4.5, Gemini 2.5 Pro, etc. |
 |   | IDE with Cline or Roo Code extension **or** Claude Desktop | Enables local tool use & file ops |
-|   | Filesystem MCP server running | Gives the AI read/write access |
+|   | [Filesystem MCP](https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem) running | Gives the agent read/write access. **Without this, Step 1 will fail silently.** |
 |   | Git & GitHub account (optional but recommended) | For version control & sharing |
 
 ---
 
-### Step 0 – Add a System Instruction or Workspace Rules file.
+### Step 0 — Set up agent rules
 
-These are sometimes called an EigenPrompt -- because they come before any other prompts.
+Agent rules act as a "pre-prompt" that shapes every response your AI coding agent gives in this session — think of them as standing instructions the model re-reads before each turn. For this 90-minute lab we'll use a tight, minimal ruleset so you can focus on the GIS work. The full, more rigorous **EigenPrompt** (the prompt that comes before all others) is collapsed below for after-class study.
 
-??? Tip "EigenPrompts"
+!!! Tip "Why agent rules?"
 
-    We are using Cline on VS Code, so we will create a unique Workspace Rules file, these are located in the `.clinerules` folder -- clicking on the :material-scales: icon will take you to Cline Rules 
+    Different agents read different files: **Cline** picks up `.clinerules/` in your workspace, **Claude Code** reads `CLAUDE.md` at the project root, and most other coding agents (Cursor, Aider, Codex, etc.) read `AGENTS.md`. Drop the same content into whichever file your tool expects.
+
+??? Clipboard "Copy/Paste — Minimal rules (use this for the lab)"
+
+    ```markdown
+    # Workshop agent rules
+
+    - Use Python 3.10+ for all scripts; for the web preview, use plain HTML/CSS/JS with no build tools or bundlers.
+    - Surface failures with clear, specific error messages. Never fabricate or hallucinate sample data — if a fetch fails, say so and stop.
+    - Log every prompt and response to `prompts/NNN_<topic>.md` using zero-padded sequential numbering (e.g., `001_setup.md`, `002_fetch_data.md`).
+    - Confirm with me before any destructive action: deleting files, overwriting existing files, or running `git push`.
+    - To preview HTML locally, run `python -m http.server <port>` on a high random port (e.g., 8723, 9412) to avoid collisions.
+    - For any data fetch, cite the source URL in a code comment immediately above the fetch call.
+    ```
+
+??? Tip "Full EigenPrompt (advanced — for after the workshop)"
+
+    These are sometimes called an EigenPrompt — because they come before any other prompts. We are using Cline on VS Code, so we will create a unique Workspace Rules file; these are located in the `.clinerules` folder — clicking on the :material-scales: icon will take you to Cline Rules.
 
     ??? Clipboard "Copy/Paste"
 
@@ -181,118 +199,80 @@ These are sometimes called an EigenPrompt -- because they come before any other 
         - **Final Output:**
           - Files: `fibonacci.py`, `test_fibonacci.py`, `README.md`.
           - Explicit confirmation that code and tests execute without errors or warnings and validation is automated successfully.
-
         ```
 
+Want to go deeper? See [Writing Prompts](../../prompts.md) and [Vibe Coding](../../vibe.md) for more on shaping agent behavior.
+
 ---
 
-### Step 1 – Initialize project folders
+### Step 1 — Scaffold project + fetch data
+
+We'll combine folder creation, dataset download, and GeoJSON sorting into a single prompt. **Open the folder you want to work in before running this prompt** — the agent creates everything relative to your current workspace.
 
 ```text
 TASK
-Create the following directory structure in the current repo  
-  data/  
-  map/  
-  code/  
-  prompts/
-Acknowledge when folders exist.
+1. Create folders: data/, map/, code/, prompts/
+2. Download https://geodacenter.github.io/data-and-lab/data/snow.zip into data/
+3. Unzip in place, delete the .zip
+4. Move every *.geojson file from the unzipped folder into map/. Ignore __MACOSX and non-geojson files.
+5. Save the script as code/setup.py and confirm each step.
 ```
+
+!!! Warning "If the download fails"
+    Grab the zip from the instructor share, or download it via your browser and drop it into `data/` manually before re-running the script.
 
 ---
 
-### Step 2 – Download & unzip “snow” dataset
+### Step 2 — Build the storymap
+
+This is the centerpiece. The agent will write the HTML/CSS/JS and serve it locally.
 
 ```text
 TASK
-1. Download https://geodacenter.github.io/data-and-lab/data/snow.zip into data/  
-2. Unzip it in place, then delete the original .zip  
-3. Write a brief summary of extracted files 
+Create map/snow_storymap.html using Leaflet (HTML/CSS/JS).
 
-Use Python scripting; save the script as code/download_data.py
+Layout:
+  - Scrolly story-map, mobile + desktop
+  - Each GeoJSON layer in map/ appears on scroll, disappears when past
+  - Short narrative caption per layer (1850 cholera context)
+
+Data styling:
+  - Choropleth on 'deaths' and 'deathdens'
+  - Death-count labels on polygons only (NOT points)
+
+Serve:
+  - Run `python -m http.server 51234` and open in browser
 ```
+
+!!! Warning "If the agent stalls or the map renders blank"
+    Skip ahead to Step 4 (one-shot) and let the agent rebuild from scratch. If port 51234 is already in use, ask the agent to pick another 5-digit port.
+
+!!! Tip "If a field is missing"
+    If `deathdens` isn't in the GeoJSON, ask the agent to compute it from `deaths` divided by polygon area.
 
 ---
 
-### Step 3 – Organize GeoJSON layers
+### Step 3 — Iterate aesthetics
+
+Critique the agent's output and ask for targeted improvements. Time-box this loop to 10 minutes.
 
 ```text
 TASK
-In the unzipped snow dataset, locate every *.geojson file.  
-Move the .geojson files into the map/ folder
-
-Ignore all other file types.  
-
-Confirm moves as successful.
+Open map/snow_storymap.html. Critique colors, fonts, and scroll feel.
+Propose up to 3 improvements. Wait for my approval, then apply them in place.
 ```
+
+!!! Tip "Running short on time?"
+    Step 3 is the most cuttable; skip straight to Step 4 if you need to.
 
 ---
 
-### Step 4 – Summarize accompanying PDFs
+### Step 4 — One-shot reveal
 
-```text
-TASK
-Within data/snow/, there are several PDF documentation files.
+Now open a fresh chat and paste the single prompt below. The pedagogical point is seeing the same workflow you just walked compressed into one prompt — that's the 2026 agent superpower.
 
-1. Extract their plain-text content and generate a markdown summary (≤ 200 words) of key variables & metadata.  
-2. Save these markdown text as data/snow_docs_summary.md
-```
-
----
-
-### Step 5 – Build a storytelling Leaflet map
-
-```text
-TASK
-Using Leaflet HTML, CSS, and JavaScript, create  
-  map/snow_storymap.html
-Requirements:
-  • The HTML must scroll like a Story Map,
-  • Layers appear when scrolled to and disappear when they are scrolled past
-  • Summarized text explains the relevance and meaning of each data set
-  • Use chloropleth colors for presence or absence of observations, such as 'deaths' and 'deathdens' for deaths and death density
-  • add the death count to polygons but not point layers
-  • Run local python web server on a high random port (e.g., 51234) to avoid conflicts  
-```
-
----
-
-### Step 6 – Iterate for aesthetics
-
-```text
-TASK
-Open map/snow_storymap.html and critique its look (colors, fonts, layout).  
-Suggest up to three improvements.  
-Wait for user approval, then implement changes inside the same file.
-```
-
----
-
-### Step 7 – Log every prompt
-
-```text
-TASK
-Create code/log_prompts.py that appends each user & assistant message  
-from this session into prompts/session_<timestamp>.md  
-Ensure it runs automatically at the end of each assistant response.
-```
-
----
-
-### Step 8 – Commit & push
-
-```text
-TASK
-Git add all new/modified files  
-Commit with message "Add snow GIS story-map lab"  
-Push to <your-GitHub-remote>  
-Report the commit URL on success.
-```
-
----
-
-### Step 9 – One Shot Prompt
-
-Now, try a new chat session and let's push everything through at once to see how it turns out:
+!!! Note "Yes, the prompt has typos"
+    The numbering jumps (two `6.`s) and "chloropleth" is misspelled. Both are preserved from the original 2025 lab on purpose — modern agents handle messy real-world prompts surprisingly well, and it's worth seeing that for yourself.
 
 ```text
 The goal for this project is to create a story map that tells the story of 1850's the cholera outbreak in London. We will use HTML, JS, CSS, and Python for the code. 
@@ -325,8 +305,36 @@ Requirements:
   • add the death count to polygons as labels, but to the not point layers
 ```
 
-### Next Steps
+Compare this output to what you built across Steps 1–3. Where did the agent do better with all-at-once context? Where did it cut corners?
 
-• Modify the prompts to use **QGISMCP** and build the layers there.
+---
 
-• Deploy the code and map via GitHub Pages.
+## Optional Homework
+
+Each link below extends a step we trimmed from the live lab — pick whichever interests you and run it on your own.
+
+### Sharpen your prompts
+
+- [Writing Prompts](../../prompts.md) — extends Step 0 with the structure behind well-engineered prompts.
+- [Vibe Coding](../../vibe.md) — deeper patterns for the iterate-with-the-agent loop you used in Step 3.
+
+### Bring documents into the workflow
+
+- [Text Mining](../../text_mining.md) — replaces the cut PDF-summary step with a richer document workflow.
+- [RAG](../../rag.md) — extends the storymap with retrieval over the cholera PDFs and other primary sources.
+
+### Automate the workflow
+
+- [Claude Code Workflow](../../claude-code.md) — covers the prompt-logging and session-automation step we skipped.
+- [Agentic AI](../../agentic.md) — frames the agent loop you just used.
+
+### Ship and extend the map
+
+- [VS Code & AI Tools](../../vscode.md) — covers the git commit/push step and IDE ergonomics.
+- [MCP](../../mcp.md) — required reading before trying QGISMCP for richer layer styling.
+- [Public Health Case Study](./casestudy.md) — applies the same agent skills to a different public-health problem.
+
+## Next Steps
+
+- Modify the prompts to use [QGISMCP](https://github.com/jjsantos01/qgis_mcp) and build the layers there.
+- Deploy the code and map via [GitHub Pages](https://pages.github.com/).


### PR DESCRIPTION
Collapses the 9-step John Snow storymap lab into 4 hands-on steps
plus a minimal agent-rules step (Step 0), with the dense ~120-line
EigenPrompt moved into a collapsible advanced section. Adds a
"What you'll build" preview, inline fallback admonitions for live
delivery, and an Optional Homework section that links to other
workshop tutorials (prompts, vibe, text_mining, rag, claude-code,
agentic, vscode, mcp, casestudy) so cut content has a home.

Drafted by 4 parallel sub-agents and validated by 3 review agents
(timing, cognitive load, technical correctness).