### PR TITLE
Docs refresh: image-gen lineup, Sora discontinuation, AI Constitutions sections

### DIFF
--- a/docs/ai_landscape.md
+++ b/docs/ai_landscape.md
@@ -16,7 +16,7 @@
             - **Computer Vision** — AI for images and video.
             - **Generative AI** — models that produce *new* content (text, images, code, audio, video).
                 - **Large Language Models (LLMs)** — generative models trained on text. ChatGPT, Claude, Gemini, Llama. The primary subject of this workshop.
-                - **Diffusion Models** — generative models for images and video (Stable Diffusion, DALL-E, Sora, Veo).
+                - **Diffusion Models** — generative models for images and video (Stable Diffusion 3.5, GPT Image, Imagen 4, Nano Banana, Veo 3).
 
     The categories blur in practice. Most "agentic AI" in 2026 combines an LLM (generative AI) with reinforcement-learning techniques (RLHF for alignment, RL for tool-use training) and classical search/planning algorithms. Use the map to locate where a specific tool sits — not to draw neat fences around it.
 
@@ -99,7 +99,7 @@ For more on agentic AI systems, see our dedicated [Agentic AI documentation](age
 
 Image: IGV System Architecture from [Yu et al. 2025 :simple-arxiv:](https://arxiv.org/abs/2504.21853){target=_blank}
 
-Unlike traditional video generation (Sora, Runway), **Interactive Generative Video** systems generate video content that responds to user input in real-time—essentially creating playable worlds from text descriptions.
+Unlike traditional video generation (Veo 3, Runway, Kling), **Interactive Generative Video** systems generate video content that responds to user input in real-time—essentially creating playable worlds from text descriptions.
 
 IGV systems combine five key modules:
 
@@ -178,7 +178,7 @@ All pricing verified **May 2026** (core AI vendors).
 **For Creative Work:**
 
 - **Images**: Midjourney (quality), ChatGPT Image (convenience), Stable Diffusion (control)
-- **Video**: Sora (OpenAI), Veo (Google), Runway Gen-4.5
+- **Video**: Veo 3 (Google), Runway Gen-4.5, Kling AI (OpenAI's Sora was discontinued April 2026)
 - **Music**: Suno, Udio
 - **Writing**: Claude (creative writing), ChatGPT, Jasper (marketing)
 
@@ -355,7 +355,7 @@ World models matter because they're the missing piece between today's reactive a
 - **V-JEPA 2** (Meta) — learns physical-world dynamics from video and is used for robot planning.
 - **GAIA-1** (Wayve) — autonomous-driving world model that predicts how a driving scene unfolds given the ego-vehicle's actions.
 - **NVIDIA Cosmos** — open foundation models for "physical AI"; the platform layer being used to build world models for robotics and autonomous systems.
-- **[Sora](https://openai.com/sora){target=_blank}** (OpenAI) and **Veo** (Google DeepMind) — video generators that learn implicit world physics. Their failure modes (object-permanence violations, gravity slips, hands with too many fingers) are diagnostic of how complete the implicit world model actually is.
+- **Veo 3** (Google DeepMind) and **Sora** (OpenAI, discontinued April 2026) — video generators that learn implicit world physics. Their failure modes (object-permanence violations, gravity slips, hands with too many fingers) are diagnostic of how complete the implicit world model actually is. Sora pioneered this framing; the discontinuation reflected economics rather than technical failure (operating costs of $8–12M/month against under $2M/month in revenue).
 
 A useful rule of thumb: if you can ask the system "what happens if I do X?" and the answer can be acted on, it's a world model. If you can only ask "what does this scene look like?", it's still generative video.
 
@@ -422,7 +422,7 @@ Large-scale AI models (LLMs, vision models, multimodal models) trained on massiv
 When an AI model generates false, nonsensical, or unfaithful information presented as fact. A key challenge in LLM reliability, especially for factual domains.
 
 **Interactive Generative Video (IGV):**
-AI systems that generate video content in real-time based on user input, combining video generation with interactive control. Unlike passive video generation (Sora, Runway), IGV systems respond to user actions in real-time, enabling gaming, simulation, and embodied AI applications.
+AI systems that generate video content in real-time based on user input, combining video generation with interactive control. Unlike passive video generation (Veo 3, Runway, Kling), IGV systems respond to user actions in real-time, enabling gaming, simulation, and embodied AI applications.
 
 **Large Language Models (LLMs):**
 A subset of foundation models trained on extensive text corpora, enabling them to generate human-like text, summarize information, reason about topics, and perform various NLP tasks. Examples: GPT, Claude, Gemini, Llama.

--- a/docs/ai_sandboxes.md
+++ b/docs/ai_sandboxes.md
@@ -137,7 +137,7 @@ When you give an AI tool permission to execute code on your computer, several th
 | Risk Level | Description | Examples |
 |------------|-------------|----------|
 | **Low** | AI provides suggestions only; you execute manually | ChatGPT web chat, Claude web interface |
-| **Medium** | AI can execute code in isolated browser environment | ChatGPT Code Interpreter, Google Colab |
+| **Medium** | AI can execute code in isolated browser environment | ChatGPT, Claude Artifacts, Gemini sandboxes; Google Colab |
 | **High** | AI can execute code on your local machine | Claude Code, Cursor, Codex CLI |
 | **Very High** | AI has unrestricted access to your system | Any tool with sandbox disabled |
 

--- a/docs/chatgpt.md
+++ b/docs/chatgpt.md
@@ -139,7 +139,7 @@ ChatGPT is powered by a family of large language models (LLMs) spanning flagship
 **Advanced Features:**
 
 - **Web Browsing:** Search the internet for current information (enabled by default for Plus users).
-- **Code Interpreter:** Run Python code, analyze data, create visualizations, and process files.
+- **Sandboxed Python:** Run Python code, analyze data, create visualizations, and process files in a browser-based sandbox.
 - **DALL-E 3:** Generate and edit images from text descriptions.
 - **Advanced Voice:** Natural, conversational voice interactions with low latency.
 

--- a/docs/chatgpt.md
+++ b/docs/chatgpt.md
@@ -52,7 +52,6 @@ ChatGPT is powered by a family of large language models (LLMs) spanning flagship
     - Limited GPT-5.x access; reasoning models throttled
     - Standard response speed
     - **Shows ads on US accounts** (rolled out Feb 9, 2026)
-    - **Sora removed from Free tier** as of Jan 10, 2026
     - Good for casual users exploring AI capabilities
 
     **ChatGPT Go ($8/month)**
@@ -70,7 +69,6 @@ ChatGPT is powered by a family of large language models (LLMs) spanning flagship
     - File uploads, voice mode, and data analysis
     - Custom GPTs and GPT Store access
     - Advanced Voice mode with natural conversation
-    - Includes 1,000 Sora credits/month
 
     **ChatGPT Pro ($100/month) `(verify)`**
 
@@ -84,7 +82,6 @@ ChatGPT is powered by a family of large language models (LLMs) spanning flagship
     - Unlimited access to frontier reasoning models
     - Unlimited access to the flagship multimodal model
     - Higher limits on advanced features
-    - Access to Sora video generation (10,000 credits + unlimited overnight Relaxed mode)
     - Deep Research tool for comprehensive analysis
     - Priority access to newest features
 
@@ -108,7 +105,7 @@ ChatGPT is powered by a family of large language models (LLMs) spanning flagship
 
 !!! note "Heads-up (May 2026)"
     - The **Free tier shows ads on US accounts** (since Feb 9, 2026).
-    - **Sora access** now requires Plus or Pro (removed from Free Jan 10, 2026).
+    - **Sora discontinued.** OpenAI shut down the Sora web and app on April 26, 2026; the API will sunset September 24, 2026. Video generation in ChatGPT is in transition; a successor model ("Spud") is reportedly in development. For video work today, migrate to [Veo 3](https://deepmind.google/technologies/veo/){target=_blank}, [Runway](https://runwayml.com/){target=_blank}, or [Kling](https://klingai.com/){target=_blank}.
     - A **new ChatGPT Pro $100/month tier** launched April 9, 2026, sitting between Plus and the $200 tier `(verify)`.
 
 !!! info "API Pricing (per million tokens, May 2026) `(verify)`"
@@ -140,7 +137,7 @@ ChatGPT is powered by a family of large language models (LLMs) spanning flagship
 
 - **Web Browsing:** Search the internet for current information (enabled by default for Plus users).
 - **Sandboxed Python:** Run Python code, analyze data, create visualizations, and process files in a browser-based sandbox.
-- **DALL-E 3:** Generate and edit images from text descriptions.
+- **GPT Image 1.5 / 2:** Generate and edit images from text descriptions (DALL-E 3 was sunset May 2026).
 - **Advanced Voice:** Natural, conversational voice interactions with low latency.
 
 ---

--- a/docs/choose.md
+++ b/docs/choose.md
@@ -80,15 +80,17 @@ Below are tables that rank popular AI platforms by use case, organized by Chat, 
 
 | **Platform** | **Strength** | **Weakness** | **Cost** | **Interface** | **Docs** |
 |--------------|--------------|--------------|----------|---------------|----------|
-| **Veo (Google)** | - High-quality video <br/>- Up to 4K resolution | - Limited daily generation | \$0.15-\$0.60/second (API) or \$19.99-\$249.99/mo (subscription via AI Pro/Ultra) | [**Veo**](https://deepmind.google/technologies/veo/){target=_blank} | [**Veo Docs**](https://ai.google.dev/gemini-api/docs/video){target=_blank} |
-| **Midjourney** | - Exceptional image quality <br/>- Web interface available | - Subscription required | $10/mo (Basic), $30/mo (Standard), $60/mo (Pro), $120/mo (Mega) | [**Midjourney**](https://www.midjourney.com/){target=_blank} | [**Midjourney Docs**](https://docs.midjourney.com/){target=_blank} |
-| **ChatGPT Image (OpenAI)** | - Native integration <br/>- Multi-turn refinement | - Earlier DALL-E versions being sunset; check current model availability | $20/mo (ChatGPT Plus) or API pricing | [**ChatGPT**](https://chatgpt.com/){target=_blank} | [**OpenAI Image Docs**](https://platform.openai.com/docs/guides/images){target=_blank} |
-| **Stable Diffusion** | - Open source <br/>- Highly customizable | - Requires technical knowledge | Free (Open Source) or API services | [**Stability AI**](https://stability.ai/){target=_blank} | [**Stable Diffusion**](https://stability.ai/stable-image){target=_blank} |
-| **Adobe Firefly** | - Creative Cloud integration <br/>- Commercial-safe | - Subscription required | \$9.99-\$29.99/mo (standalone) or \$70/mo (CC Pro) | [**Firefly**](https://firefly.adobe.com/){target=_blank} | [**Firefly Docs**](https://developer.adobe.com/firefly-services/docs/guides/){target=_blank} |
-| **Sora (OpenAI)** | - Text-to-video <br/>- Up to 1080p | ⚠️ **NOT available in EU/UK** | $20/mo (ChatGPT Plus), $200/mo (ChatGPT Pro) | [**Sora**](https://openai.com/sora){target=_blank} | [**Sora Research**](https://openai.com/research/video-generation-models-as-world-simulators){target=_blank} |
-| **Runway ML** | - Advanced video tools <br/>- Latest generation models | - Higher-res requires paid plans | $15/mo (monthly), $12/mo (annual) to $95/mo | [**Runway**](https://runwayml.com/){target=_blank} | [**Runway Docs**](https://docs.runwayml.com/){target=_blank} |
-| **Imagine with Meta** | - Free image generation <br/>- Meta AI integration | - Quality less advanced | Free, $30/mo (Meta AI+ optional) | [**Meta AI**](https://www.meta.ai/){target=_blank} | [**Meta Help**](https://www.meta.com/help/artificial-intelligence/imagine/){target=_blank} |
-| **Craiyon** | - Simple free tier <br/>- Unlimited base quality | - Lower quality on free tier | Free (unlimited Base w/ ads), $5-12/mo (Supporter), $20-24/mo (Professional) | [**Craiyon**](https://www.craiyon.com/){target=_blank} | FAQ on site |
+| **Gemini Nano Banana 2 (Google)** | - State-of-the-art image editing <br/>- Multi-image fusion, character consistency <br/>- Conversational refinement <br/>- SynthID watermark on every output | - Editing-first model; pure txt2img not always best | ~$0.039/image (Gemini API) or included in Gemini AI Pro/Ultra | [**Gemini**](https://gemini.google.com/){target=_blank} | [**Nano Banana Docs**](https://ai.google.dev/gemini-api/docs/image-generation){target=_blank} |
+| **GPT Image 1.5 / 2 (OpenAI)** | - Top-ranked on human-vote leaderboards (May 2026) <br/>- Native ChatGPT integration <br/>- Strong text rendering and instruction following | - Higher per-image cost than Gemini <br/>- Geographic restrictions on some features | $20/mo (ChatGPT Plus) or per-image API pricing | [**ChatGPT**](https://chatgpt.com/){target=_blank} | [**OpenAI Image Docs**](https://platform.openai.com/docs/guides/images){target=_blank} |
+| **Imagen 4 / Imagen 4 Ultra (Google)** | - Best-in-class photorealism <br/>- Strong text rendering | - Vertex AI / API only | Per-image API pricing via Vertex AI | [**Imagen**](https://deepmind.google/models/imagen/){target=_blank} | [**Imagen Docs**](https://ai.google.dev/gemini-api/docs/imagen){target=_blank} |
+| **Midjourney v7** | - Exceptional artistic quality <br/>- Web interface available | - Subscription required | $10/mo (Basic), $30/mo (Standard), $60/mo (Pro), $120/mo (Mega) | [**Midjourney**](https://www.midjourney.com/){target=_blank} | [**Midjourney Docs**](https://docs.midjourney.com/){target=_blank} |
+| **FLUX 1.1 Pro / FLUX 2 Pro (Black Forest Labs)** | - Best technical quality + speed <br/>- Open-weight tiers (Schnell, dev) | - Pro tiers API-only | Free open-weights (Schnell/dev) or per-image API | [**Black Forest Labs**](https://bfl.ai/){target=_blank} | [**FLUX Docs**](https://docs.bfl.ai/){target=_blank} |
+| **Ideogram v3** | - Best-in-class text rendering and typography | - Less photorealistic than Imagen 4 | Free tier; $7-$48/mo paid plans | [**Ideogram**](https://ideogram.ai/){target=_blank} | [**Ideogram Docs**](https://developer.ideogram.ai){target=_blank} |
+| **Stable Diffusion 3.5 (Stability AI)** | - Open source <br/>- Highly customizable, runs locally | - Requires technical knowledge | Free (open weights) or API services | [**Stability AI**](https://stability.ai/){target=_blank} | [**SD 3.5**](https://stability.ai/news/introducing-stable-diffusion-3-5){target=_blank} |
+| **Adobe Firefly** | - Creative Cloud integration <br/>- Commercial-safe training data | - Subscription required | $9.99-$29.99/mo (standalone) or $70/mo (CC Pro) | [**Firefly**](https://firefly.adobe.com/){target=_blank} | [**Firefly Docs**](https://developer.adobe.com/firefly-services/docs/guides/){target=_blank} |
+| **Veo 3 (Google)** | - High-quality video with native audio <br/>- Up to 4K resolution | - Limited daily generation on consumer tiers | $0.15-$0.60/second (API) or $19.99-$249.99/mo (subscription via AI Pro/Ultra) | [**Veo**](https://deepmind.google/technologies/veo/){target=_blank} | [**Veo Docs**](https://ai.google.dev/gemini-api/docs/video){target=_blank} |
+| **Sora 2 (OpenAI)** | - Text-to-video with native audio <br/>- Up to 1080p | ⚠️ **NOT available in EU/UK** | $20/mo (ChatGPT Plus), $200/mo (ChatGPT Pro) | [**Sora**](https://openai.com/sora){target=_blank} | [**Sora Research**](https://openai.com/research/video-generation-models-as-world-simulators){target=_blank} |
+| **Runway ML** | - Professional video tools <br/>- Latest generation models | - Higher-res requires paid plans | $15/mo (monthly), $12/mo (annual) to $95/mo | [**Runway**](https://runwayml.com/){target=_blank} | [**Runway Docs**](https://docs.runwayml.com/){target=_blank} |
 
 ---
 
@@ -96,23 +98,86 @@ Below are tables that rank popular AI platforms by use case, organized by Chat, 
 
     ## **Image Generation Models**
 
-    The image generation landscape includes both commercial platforms and open-source options:
+    The image-generation landscape in May 2026 has consolidated around a small set of multimodal frontier models (Nano Banana, GPT Image, Imagen 4) plus standalone leaders for artistic, technical, and typography work, alongside a strong open-weight ecosystem.
 
-    **Commercial Platforms:**
+    **Multimodal chat-integrated (current leaders for editing and conversational refinement):**
 
-    *   [**Midjourney**](https://www.midjourney.com/){target=_blank}: Known for exceptional artistic quality and aesthetics. Discord and web interface available.
-    *   [**ChatGPT Image Generation**](https://openai.com/index/introducing-4o-image-generation/){target=_blank} (OpenAI): Native integration with ChatGPT, good text rendering, iterative refinement.
-    *   [**Google Imagen**](https://deepmind.google/models/imagen/){target=_blank}: Strong photo-realism and text rendering. Available via Gemini API.
-    *   [**Adobe Firefly**](https://firefly.adobe.com/){target=_blank}: Commercial-safe training data, Creative Cloud integration.
-    *   [**Ideogram**](https://ideogram.ai/){target=_blank}: Strong text rendering and style references.
-    *   [**Leonardo**](https://leonardo.ai/){target=_blank}: Versatile with multiple style options.
-    *   [**Recraft**](https://www.recraft.ai/){target=_blank}: Vector art generation and extended text capabilities.
+    *   [**Gemini 2.5 Flash Image / Nano Banana 2**](https://deepmind.google/models/gemini-image/){target=_blank} (Google): State-of-the-art editing model. Multi-image fusion, character/style consistency across generations, targeted local edits via natural language ("blur the background," "remove the truck," "change the pose"), and SynthID watermarking on every output. Best for high-volume generation, conversational editing, and synthetic-data workflows. Nano Banana Pro / Nano Banana 2 (Gemini 3 Pro Image) adds 4K photorealism. ([API docs](https://ai.google.dev/gemini-api/docs/image-generation){target=_blank})
+    *   [**GPT Image 1.5 / GPT Image 2**](https://platform.openai.com/docs/guides/images){target=_blank} (OpenAI): Top-ranked on the [LLM Stats human-vote leaderboard](https://llm-stats.com/leaderboards/best-ai-for-image-generation){target=_blank} (May 2026). Native ChatGPT integration, strong instruction following, multi-turn refinement. Replaced DALL-E 3.
+    *   [**Imagen 4 / Imagen 4 Ultra**](https://deepmind.google/models/imagen/){target=_blank} (Google): Best-in-class photorealism and text rendering. Available via Vertex AI and the Gemini API.
 
-    **Open-Source Options:**
+    **Standalone commercial leaders:**
 
-    *   [**Stable Diffusion**](https://stability.ai/stable-diffusion-3-5){target=_blank} (Stability AI): Highly customizable, can run locally. Available on [HuggingFace](https://huggingface.co/stabilityai){target=_blank}.
-    *   [**FLUX**](https://bfl.ai/){target=_blank} (Black Forest Labs): Multiple variants for different use cases, Apache-licensed options available.
-    *   [**HiDream**](https://hidream.org/){target=_blank}: Open-source (MIT license).
+    *   [**Midjourney v7**](https://www.midjourney.com/){target=_blank}: Released April 2025. Still the benchmark for artistic and aesthetic image quality. Web and Discord interfaces.
+    *   [**FLUX 1.1 Pro / FLUX 2 Pro**](https://bfl.ai/){target=_blank} (Black Forest Labs): Best technical quality plus speed (~4.5s generation). Often the best default for general commercial use. Open-weight tiers (Schnell, dev) also available.
+    *   [**Ideogram v3**](https://ideogram.ai/){target=_blank}: Owns the typography niche. If text rendering matters in your output, start here.
+    *   [**Adobe Firefly**](https://firefly.adobe.com/){target=_blank}: Commercial-safe training data, deep Creative Cloud integration. Important if you need indemnification for client work.
+    *   [**Recraft V3**](https://www.recraft.ai/){target=_blank}: Vector art generation and extended text capabilities; popular for design workflows.
+    *   [**Reve Image 1.0**](https://reve.art/){target=_blank}: Newer entrant (2025) competing on prompt adherence.
+    *   [**Riverflow 2.0 Pro**](https://llm-stats.com/leaderboards/best-ai-for-image-generation){target=_blank}: Leaderboard top-three (May 2026); strong all-rounder.
+
+    **Open-source / open-weight:**
+
+    *   [**Stable Diffusion 3.5**](https://stability.ai/news/introducing-stable-diffusion-3-5){target=_blank} (Stability AI): Major step forward over SD 3. Highly customizable, runs locally. Available on [HuggingFace](https://huggingface.co/stabilityai){target=_blank}.
+    *   [**FLUX.1 Schnell / FLUX.1 dev**](https://bfl.ai/){target=_blank} (Black Forest Labs): Open-weight tiers of FLUX, Apache-licensed (Schnell) and non-commercial (dev). Strong baseline for self-hosting.
+    *   [**HiDream-I1**](https://hidream.org/){target=_blank}: MIT-licensed, fully open.
+    *   [**Qwen Image**](https://huggingface.co/Qwen){target=_blank} (Alibaba): Strong open-weight alternative with multilingual prompt support.
+
+    !!! example "Synthetic data for downstream model training: storm damage assessment from drone imagery"
+
+        Drone imagery for disaster-damage classification is hard to come by — major storms are infrequent, drones often can't fly during or immediately after, and labeled examples of severe damage are especially scarce. Multimodal image-editing models like Gemini 2.5 Flash Image (Nano Banana) can systematically expand a small seed dataset of real drone images into a much larger paired training set with controlled variation across damage severity, structure type, and environmental conditions.
+
+        **Workflow**
+
+        1. **Collect a seed dataset.** Start with a small set of real labeled nadir-view drone images — for example, 200 images of intact rural rooftops captured at known altitudes between 60–100 m AGL.
+
+        2. **Generate damage variants per scene.** For each seed image, prompt Nano Banana to produce a paired set of damage variants while preserving the underlying scene:
+
+            ```
+            I'm uploading a nadir drone image of an intact rural metal-panel roof
+            captured at ~80 m altitude. Generate four variants of the same scene at
+            the same camera angle, lighting, and surrounding vegetation, varying
+            ONLY the roof condition:
+
+            1. Light damage: 1-2 panels lifted, debris scattered around the perimeter
+            2. Moderate damage: ~30% of panels missing, some structural deformation
+            3. Severe damage: ~70% of panels missing, partial wall collapse on one side
+            4. Total loss: roof completely removed, exposed framing and interior visible
+
+            Maintain consistent perspective, vegetation, time of day, and shadow
+            direction across all four variants so they form a paired training set.
+            ```
+
+        3. **Generate environmental variants.** For each seed-plus-damage combination, vary lighting, weather, and seasonal conditions to teach the downstream model invariances:
+
+            ```
+            Take this drone image and generate four variants for: overcast midday,
+            golden-hour side-lit, low-altitude haze after rainfall, and partial cloud
+            shadow. Keep the roof condition, structure, and surrounding vegetation
+            identical across all four.
+            ```
+
+        4. **Generate structure-type diversity.** Use multi-image fusion to combine your scene templates with different roof morphologies (residential gable, commercial flat, agricultural barn) while preserving the damage signatures from step 2.
+
+        5. **Train your downstream classifier** (e.g., YOLOv8 for object detection, ResNet or a vision transformer for damage-class scoring) on the combined real + synthetic dataset. **Reserve a real-only test set** for honest evaluation.
+
+        **Why Nano Banana fits this workflow**
+
+        - **Scene consistency across edits** means damage variants share the same underlying structure, giving cleanly paired before/after training examples — hard to do with standalone txt2img models.
+        - **Multi-image fusion** lets you blend a real scene with a reference damage example to produce hybrids that retain your scene's geometry.
+        - **Conversational refinement** lets you iterate on a single variant ("more debris around the eaves," "less smoke on the right side") instead of re-rolling from scratch.
+        - **Low cost per image** (~$0.039 via API) makes augmenting a 200-image seed into a 10,000-image training set tractable (~$390).
+        - **Automatic SynthID watermarking** is invisible but detectable — important for documenting the synthetic provenance of every generated image in your training corpus.
+
+        **Caveats and methodological hygiene**
+
+        - **Validate on real data only.** Synthetic data narrows your training distribution in ways that often don't show up at training time. Always reserve a real-only test split, and report performance on it separately.
+        - **Domain gap.** Generated imagery can miss sensor-specific artifacts (rolling shutter, lens distortion, sensor noise, JPEG compression). Models trained heavily on synthetic data sometimes overfit to "synthetic-looking" features and degrade on real deployment.
+        - **Bias amplification.** If your seed images skew toward one geography, structure type, season, or altitude, synthetic variants amplify that skew. Audit class balance and sub-population coverage after augmentation.
+        - **Disclosure.** If you publish a model trained on synthetic data, document the generation workflow, prompt templates, sample sizes, and SynthID provenance in your methods section. Some journals and conferences now require it.
+        - **Validation against ground truth.** For high-stakes deployments (insurance estimation, FEMA damage assessment, search-and-rescue prioritization), pair synthetic augmentation with physics-based scene synthesis or labeled real datasets like [xBD](https://xview2.org){target=_blank} (building damage from satellite imagery) and [LADI](https://github.com/LADI-Dataset/ladi-overview){target=_blank} (low-altitude disaster imagery).
+
+        For the broader synthetic-data discussion in earth observation and disaster response, see also [Veo 3](https://deepmind.google/technologies/veo/){target=_blank} for video augmentation and physics-based CGI pipelines for defensible ground truth.
 
     ## **Video Generation Models**
 
@@ -210,7 +275,7 @@ For more information on using AI for tutoring and education, see [AI Tutoring: S
 
     * **SearchGPT** - Merged into ChatGPT (no longer standalone)
     * **Code Llama** - Repository archived July 2025 (consider StarCoder instead)
-    * **DALL-E** - Version 3 being sunset May 2026 (replaced by GPT-4o Image Generation)
+    * **DALL-E 3** - Sunset May 2026 (replaced by GPT Image 1.5 / GPT Image 2)
 
 !!! Tip "Best Options for Students & Educators"
 
@@ -251,6 +316,9 @@ Agentic browsers integrate AI directly into your web browsing experience, enabli
 | [**Genspark AI Browser**](https://www.genspark.ai){target=_blank} | [Free](https://www.genspark.ai/pricing){target=_blank} | $0 | 100 credits daily, Super Agent Everywhere, Autopilot Mode, 700+ MCP tool integrations |
 | | [Plus](https://www.genspark.ai/pricing){target=_blank} | $24.99 | 10,000 credits monthly, priority AI agent access, top-tier models, AI Slides/Sheets/Docs |
 | | [Pro](https://www.genspark.ai/pricing){target=_blank} | $249.99 | 125,000 credits monthly, full Super Agent access, phone calls, video generation |
+| [**Google Chrome + Gemini**](https://gemini.google/overview/gemini-in-chrome/){target=_blank} | [Free](https://www.google.com/chrome/){target=_blank} | $0 | Gemini side panel (right rail), page summarization, cross-tab Q&A, in-browser Nano Banana image transformation, voice-driven browsing <br> **Free with any Google account** |
+| | [Google AI Pro](https://gemini.google.com/){target=_blank} | $19.99 | **Auto Browse** (launched Jan 2026): agentic multi-step tasks — shopping, form filling, hotel/flight research, scheduling, subscription management. Personal Intelligence (calendar/email) rolling out <br> **US-only at launch** |
+| | [Google AI Ultra](https://gemini.google.com/){target=_blank} | $249.99 | Higher Auto Browse limits, Gemini 3 Pro/Ultra access for deeper reasoning on agentic tasks |
 | [**Microsoft Edge Copilot Mode**](https://www.microsoft.com/edge){target=_blank} | [Free (Experimental)](https://www.microsoft.com/en-us/edge/features/copilot){target=_blank} | $0 | Cross-tab awareness, task automation, in-page assistance, browser history/credentials access <br> **Windows/Mac, opt-in** |
 | [**Opera One + Aria**](https://www.opera.com/features/aria){target=_blank} | [Free](https://www.opera.com/){target=_blank} | $0 | Free AI assistant, real-time web access, page context mode, image generation, tab commands, local AI models <br> **No account required** |
 | [**Brave + Leo AI**](https://brave.com/leo/){target=_blank} | [Free](https://brave.com/){target=_blank} | $0 | Privacy-first AI, Llama, Mixtral, Claude Haiku, Qwen, content awareness, zero data retention |
@@ -258,11 +326,11 @@ Agentic browsers integrate AI directly into your web browsing experience, enabli
 
 **Notes on Agentic Browsers:**
 
-*   **True Agentic Capabilities:** Comet, Fellou, Opera Neon, Dia, and Genspark can autonomously perform multi-step tasks (booking, purchasing, form filling)
+*   **True Agentic Capabilities:** Comet, Fellou, Opera Neon, Dia, Genspark, and Google Chrome (Auto Browse, AI Pro/Ultra) can autonomously perform multi-step tasks (booking, purchasing, form filling)
 *   **AI-Enhanced:** Microsoft Edge Copilot Mode, Opera One, and Brave Leo provide AI assistance but with less autonomous action
+*   **Major-vendor entry:** Google Chrome added agentic Auto Browse in January 2026, bringing autonomous web tasks into the world's most-used browser. Requires Google AI Pro or Ultra; US-only at launch.
 *   **Platform Availability:** Most are Chromium-based; Dia is macOS only (M1+); Others support Windows/Mac/Linux
 *   **Privacy Considerations:** Check each browser's data policies - some use cloud AI, others offer local processing
-*   **Coming Soon:** OpenAI browser expected late 2025 with ChatGPT integration and Operator agent
 
 ---
 

--- a/docs/choose.md
+++ b/docs/choose.md
@@ -89,7 +89,7 @@ Below are tables that rank popular AI platforms by use case, organized by Chat, 
 | **Stable Diffusion 3.5 (Stability AI)** | - Open source <br/>- Highly customizable, runs locally | - Requires technical knowledge | Free (open weights) or API services | [**Stability AI**](https://stability.ai/){target=_blank} | [**SD 3.5**](https://stability.ai/news/introducing-stable-diffusion-3-5){target=_blank} |
 | **Adobe Firefly** | - Creative Cloud integration <br/>- Commercial-safe training data | - Subscription required | $9.99-$29.99/mo (standalone) or $70/mo (CC Pro) | [**Firefly**](https://firefly.adobe.com/){target=_blank} | [**Firefly Docs**](https://developer.adobe.com/firefly-services/docs/guides/){target=_blank} |
 | **Veo 3 (Google)** | - High-quality video with native audio <br/>- Up to 4K resolution | - Limited daily generation on consumer tiers | $0.15-$0.60/second (API) or $19.99-$249.99/mo (subscription via AI Pro/Ultra) | [**Veo**](https://deepmind.google/technologies/veo/){target=_blank} | [**Veo Docs**](https://ai.google.dev/gemini-api/docs/video){target=_blank} |
-| **Sora 2 (OpenAI)** | - Text-to-video with native audio <br/>- Up to 1080p | ⚠️ **NOT available in EU/UK** | $20/mo (ChatGPT Plus), $200/mo (ChatGPT Pro) | [**Sora**](https://openai.com/sora){target=_blank} | [**Sora Research**](https://openai.com/research/video-generation-models-as-world-simulators){target=_blank} |
+| **Sora 2 (OpenAI)** | - Text-to-video with native audio <br/>- Up to 1080p | ⚠️ **DISCONTINUED** — web/app shut down April 26, 2026; API sunset Sept 24, 2026. Use Veo 3, Runway, or Kling instead | Was $20/mo (Plus), $200/mo (Pro) | [**Sora discontinuation FAQ**](https://help.openai.com/en/articles/20001152-what-to-know-about-the-sora-discontinuation){target=_blank} | — |
 | **Runway ML** | - Professional video tools <br/>- Latest generation models | - Higher-res requires paid plans | $15/mo (monthly), $12/mo (annual) to $95/mo | [**Runway**](https://runwayml.com/){target=_blank} | [**Runway Docs**](https://docs.runwayml.com/){target=_blank} |
 
 ---
@@ -185,7 +185,7 @@ Below are tables that rank popular AI platforms by use case, organized by Chat, 
 
     **Commercial Platforms:**
 
-    *   [**Sora**](https://openai.com/sora){target=_blank} (OpenAI): Text-to-video with native audio. Available to ChatGPT Plus/Pro subscribers. Not available in EU/UK.
+    *   ~~[**Sora**](https://openai.com/sora){target=_blank} (OpenAI)~~ — **DISCONTINUED**: web and app shut down April 26, 2026; API sunset Sept 24, 2026. OpenAI cited operating costs of $8–12M/month against under $2M/month in revenue. A successor model called "Spud" is reportedly in development. Migrate to Veo 3, Runway, or Kling.
     *   [**Veo**](https://deepmind.google/models/veo/){target=_blank} (Google): High-quality video with native audio. Available via Gemini API and Google AI Studio.
     *   [**Runway**](https://runwayml.com/){target=_blank}: Professional video tools with world consistency features.
     *   [**Pika**](https://pika.art/){target=_blank}: Keyframe-based video creation.
@@ -276,6 +276,7 @@ For more information on using AI for tutoring and education, see [AI Tutoring: S
     * **SearchGPT** - Merged into ChatGPT (no longer standalone)
     * **Code Llama** - Repository archived July 2025 (consider StarCoder instead)
     * **DALL-E 3** - Sunset May 2026 (replaced by GPT Image 1.5 / GPT Image 2)
+    * **Sora / Sora 2** - Discontinued by OpenAI: web and app shut down April 26, 2026; API sunset September 24, 2026. Successor model "Spud" reportedly in development. Migrate to Veo 3, Runway, or Kling.
 
 !!! Tip "Best Options for Students & Educators"
 

--- a/docs/ethics.md
+++ b/docs/ethics.md
@@ -21,6 +21,28 @@ Over the next 70 years, Artificial Intelligence persisted mainly in [the minds o
 
 As consumers of GPTs and other AI platforms, we must consider in what ways can we use AI both effectively, and ethically.
 
+## AI Constitutions and Bills of Rights
+
+How should the values that guide AI systems be set, and by whom? Two distinct approaches have emerged: **corporate AI constitutions** written by AI companies for their own models (Anthropic's *Claude Constitution* is the canonical example), and **public AI bills of rights** developed through democratic processes (the White House *Blueprint for an AI Bill of Rights*, October 2022, is the leading example).
+
+Sociologist [Alondra Nelson](https://www.ias.edu/sss/faculty/nelson){target=_blank} — who led the development of the Blueprint while serving as acting director of the White House Office of Science and Technology Policy (OSTP) — argues in [*A civic grammar for AI rights*](https://www.science.org/doi/10.1126/science.aeh7153){target=_blank} (Science, 2026) that these two forms of foundational document do very different work:
+
+- **Corporate AI constitutions** are internal training and alignment specifications. They describe a company's vision of how its model should behave, but they are not negotiated with the publics affected by the model's deployment, and they can be revised by company fiat. Nelson notes, for example, that newer revisions of Anthropic's Claude Constitution have quietly removed references to international human rights agreements — and with them protections for personal liberty, freedom of religion, and intellectual property that earlier versions included.
+- **Public AI bills of rights** declare rights claims that publics can extend to new institutions and new harms. Their force comes from democratic legitimacy and the broader legal and political infrastructure around them, not from the model developers themselves.
+
+Nelson describes the result as a **"civic grammar"** — a shared vocabulary of rights claims (privacy, non-discrimination, due process, notice, recourse) that the public has built up over decades and can now extend to AI systems. The political question, in her framing, is *who gets to author the foundational documents that govern AI* — companies, or publics?
+
+The structural comparison matters. The Blueprint for an AI Bill of Rights, Nelson notes, is closer to the **Declaration of Independence** than to the actual **Bill of Rights**: it declares principles and asserts claims against concentrated power, but it does not establish courts, enforcement mechanisms, or procedures for redress. Closing that gap — moving from declaration to enforceable rights — is the work that remains.
+
+For the specific principles in the Blueprint and their current legal status, see [Ethical & Legal Considerations: Blueprint for an AI Bill of Rights](legal.md#blueprint-for-an-ai-bill-of-rights).
+
+!!! info "Further reading"
+
+    - Alondra Nelson, [*A civic grammar for AI rights*](https://www.science.org/doi/10.1126/science.aeh7153){target=_blank}, *Science* (2026). DOI: 10.1126/science.aeh7153
+    - Alondra Nelson, [Bluesky thread on these principles](https://bsky.app/profile/alondra.bsky.social/post/3mltfqoc7ok2y){target=_blank}
+    - [Blueprint for an AI Bill of Rights](https://bidenwhitehouse.archives.gov/ostp/ai-bill-of-rights/){target=_blank} (White House OSTP, October 2022, archived)
+    - Anthropic, [Claude's Constitution](https://www.anthropic.com/news/claudes-constitution){target=_blank}
+
 ## [:material-scale-balance: Ethical and Legal Considerations](legal.md)
 
 ## [:material-mirror: Transparency & Accountability](transparency.md)

--- a/docs/ethics.md
+++ b/docs/ethics.md
@@ -25,21 +25,40 @@ As consumers of GPTs and other AI platforms, we must consider in what ways can w
 
 How should the values that guide AI systems be set, and by whom? Two distinct approaches have emerged: **corporate AI constitutions** written by AI companies for their own models (Anthropic's *Claude Constitution* is the canonical example), and **public AI bills of rights** developed through democratic processes (the White House *Blueprint for an AI Bill of Rights*, October 2022, is the leading example).
 
-Sociologist [Alondra Nelson](https://www.ias.edu/sss/faculty/nelson){target=_blank} — who led the development of the Blueprint while serving as acting director of the White House Office of Science and Technology Policy (OSTP) — argues in [*A civic grammar for AI rights*](https://www.science.org/doi/10.1126/science.aeh7153){target=_blank} (Science, 2026) that these two forms of foundational document do very different work:
+Sociologist [Alondra Nelson](https://www.ias.edu/sss/faculty/nelson){target=_blank} — who led the Blueprint's development as acting director of the White House Office of Science and Technology Policy (OSTP) — argues in [*A civic grammar for AI rights*](https://www.science.org/doi/10.1126/science.aeh7153){target=_blank} (Science, 2026) that these two forms of foundational document do very different work, and that one of them is structurally insufficient as a source of democratic legitimacy.
 
-- **Corporate AI constitutions** are internal training and alignment specifications. They describe a company's vision of how its model should behave, but they are not negotiated with the publics affected by the model's deployment, and they can be revised by company fiat. Nelson notes, for example, that newer revisions of Anthropic's Claude Constitution have quietly removed references to international human rights agreements — and with them protections for personal liberty, freedom of religion, and intellectual property that earlier versions included.
-- **Public AI bills of rights** declare rights claims that publics can extend to new institutions and new harms. Their force comes from democratic legitimacy and the broader legal and political infrastructure around them, not from the model developers themselves.
+### Corporate constitutions vs. public bills of rights
 
-Nelson describes the result as a **"civic grammar"** — a shared vocabulary of rights claims (privacy, non-discrimination, due process, notice, recourse) that the public has built up over decades and can now extend to AI systems. The political question, in her framing, is *who gets to author the foundational documents that govern AI* — companies, or publics?
+- **Corporate AI constitutions** are internal training and alignment specifications. They describe a company's vision of how its model should behave. They are not negotiated with the publics affected by the model's deployment, and they can be revised by company fiat. Nelson notes that newer revisions of Anthropic's Claude Constitution have quietly removed references to international human rights agreements — and with them protections for "personal liberty, freedom of religion and intellectual property," and other rights that earlier versions included. Historian Jill Lepore observed that the document arrived *"at a trying time for both artificial intelligence and constitutional democracy."*
+- **Public AI bills of rights** declare rights claims that publics can extend to new institutions and new harms. Their force comes from democratic legitimacy and the broader legal-political infrastructure, not from the model developers. The Blueprint took its name from the first ten amendments to the U.S. Constitution but, Nelson argues, structurally resembles a different founding document — the **Declaration of Independence**. It declares principles and claims rights against concentrated power, but it does not establish courts, enforcement mechanisms, or procedures for redress.
 
-The structural comparison matters. The Blueprint for an AI Bill of Rights, Nelson notes, is closer to the **Declaration of Independence** than to the actual **Bill of Rights**: it declares principles and asserts claims against concentrated power, but it does not establish courts, enforcement mechanisms, or procedures for redress. Closing that gap — moving from declaration to enforceable rights — is the work that remains.
+### "Civic grammar" and the diffusion of rights claims
 
-For the specific principles in the Blueprint and their current legal status, see [Ethical & Legal Considerations: Blueprint for an AI Bill of Rights](legal.md#blueprint-for-an-ai-bill-of-rights).
+Nelson describes what has emerged as a **"civic grammar"**: a shared vocabulary of rights claims (non-discrimination, transparency, data privacy, notice, human alternatives) that publics can extend to new institutions and new harms, and that "has been traveling across jurisdictions, partisan lines, and institutional contexts." The American tradition is long — Patients' Bill of Rights, Consumer Bill of Rights, Tenants' Bill of Rights, Workers' Bill of Rights, Taxpayers' Bill of Rights — and the AI Bill of Rights template has spread the same way: actors with no shared political coalition, sometimes with explicit antipathy toward each other, adopting a common vocabulary because each, separately, has encountered the same kind of algorithmic harm.
 
-!!! info "Further reading"
+This pattern reflects what sociologists David Strang and John Meyer call **institutional diffusion** among *weakly related actors* — a conceptual rather than relational mechanism by which abstract typologies become "a strategy for making sense of the world." Connecticut Democrats, Oklahoma Republicans, Florida's Republican governor, and a national student-advocacy network can adopt the same vocabulary without coordinating, because all are responding to the same structural condition: AI reshaping people's lives without their consultation. (For the specific state-level examples and the international convergence, see [Blueprint for an AI Bill of Rights](legal.md#blueprint-for-an-ai-bill-of-rights) in the Legal lesson.)
+
+### Marshall's social citizenship and the AI rights tier
+
+Nelson grounds the analysis in British sociologist T. H. Marshall's 1950 essay *Citizenship and Social Class*. Marshall argued that rights expand historically through successive waves of claim-making: civil rights extending to political rights, political rights extending to **social rights** — entitlements to economic security and the conditions of participation, against harms of industrial capitalism that individual civil-liberties frameworks could not address. Rights, in Marshall's account, "are never fully delivered at the moment of declaration. They are successively rearticulated by publics who attempt to hold institutions to commitments those institutions have not yet honored."
+
+The Blueprint's five principles, Nelson argues, map onto Marshall's social-rights tier. They are not classical civil liberties; they are entitlements against systems "that increasingly govern access to employment, credit, healthcare, housing, and education." The structural parallel — collective, diffuse, opaque harms that older rights frameworks address only partially — is what explains the cross-partisan convergence: "actors who disagree on nearly everything else agree that algorithmic power requires a social citizenship response."
+
+### The limits of rights talk
+
+Nelson is clear-eyed about what civic grammar cannot do on its own:
+
+- **Accommodation can mimic transformation.** A vocabulary that moves easily across partisan lines may have been "drained of the political content that gives rights claims their force."
+- **Rights individualize structural problems.** Frameworks built around individual claims often fail to address the collective and systemic nature of algorithmic harms.
+- **Declaration is not delivery.** History shows "declarations of entitlement and their substantive delivery can remain decades apart, separated by the organized power of those who benefit from the status quo."
+
+Nelson's clarifying question for democratic institutions: *will they take this civic grammar seriously before the AI companies finish writing their own constitutions for us all?*
+
+!!! info "Sources and further reading"
 
     - Alondra Nelson, [*A civic grammar for AI rights*](https://www.science.org/doi/10.1126/science.aeh7153){target=_blank}, *Science* (2026). DOI: 10.1126/science.aeh7153
     - Alondra Nelson, [Bluesky thread on these principles](https://bsky.app/profile/alondra.bsky.social/post/3mltfqoc7ok2y){target=_blank}
+    - T. H. Marshall, "Citizenship and Social Class" (1950)
     - [Blueprint for an AI Bill of Rights](https://bidenwhitehouse.archives.gov/ostp/ai-bill-of-rights/){target=_blank} (White House OSTP, October 2022, archived)
     - Anthropic, [Claude's Constitution](https://www.anthropic.com/news/claudes-constitution){target=_blank}
 

--- a/docs/legal.md
+++ b/docs/legal.md
@@ -122,7 +122,9 @@ In response to the rapid rise of generative AI, specifically GPTs, new agreement
 
 ## Blueprint for an AI Bill of Rights
 
-The [**Blueprint for an AI Bill of Rights**](https://bidenwhitehouse.archives.gov/ostp/ai-bill-of-rights/){target=_blank} was released by the White House Office of Science and Technology Policy (OSTP) in October 2022. It proposed five principles to guide the design, development, and deployment of automated systems:
+### Timeline and status
+
+The [**Blueprint for an AI Bill of Rights**](https://bidenwhitehouse.archives.gov/ostp/ai-bill-of-rights/){target=_blank} emerged from a public process announced in an October 2021 *Wired* essay by the White House Office of Science and Technology Policy (OSTP). It was released in October 2022 with **five principles** to guide the design, development, and deployment of automated systems:
 
 1. **Safe and Effective Systems** — protection from unsafe or ineffective systems.
 2. **Algorithmic Discrimination Protections** — equitable design and use of automated systems.
@@ -130,21 +132,50 @@ The [**Blueprint for an AI Bill of Rights**](https://bidenwhitehouse.archives.go
 4. **Notice and Explanation** — knowing when an automated system is being used and how/why it affects you.
 5. **Human Alternatives, Consideration, and Fallback** — the ability to opt out and reach a human alternative when an automated system fails or causes harm.
 
-The companion [Executive Order on Safe, Secure, and Trustworthy Development and Use of Artificial Intelligence](https://www.federalregister.gov/documents/2023/11/01/2023-24283/safe-secure-and-trustworthy-development-and-use-of-artificial-intelligence){target=_blank} (October 2023) operationalized parts of this framework for federal agencies. **Both the Blueprint and the Executive Order have been rescinded by the current administration.**
+These principles were incorporated into President Biden's [October 2023 Executive Order on Safe, Secure, and Trustworthy AI](https://www.federalregister.gov/documents/2023/11/01/2023-24283/safe-secure-and-trustworthy-development-and-use-of-artificial-intelligence){target=_blank}. The Executive Order was rescinded by President Trump's January 2025 [Removing Barriers to American Leadership in Artificial Intelligence](https://www.whitehouse.gov/presidential-actions/2025/01/removing-barriers-to-american-leadership-in-artificial-intelligence/){target=_blank}. The Blueprint itself was always non-binding guidance.
 
 ### Constitution vs. Bill of Rights vs. Declaration of Independence
 
-Sociologist [Alondra Nelson](https://www.ias.edu/sss/faculty/nelson){target=_blank} — who led the Blueprint's development as acting director of OSTP — has argued in [*A civic grammar for AI rights*](https://www.science.org/doi/10.1126/science.aeh7153){target=_blank} (Science, 2026) that the Blueprint is structurally closer to the **Declaration of Independence** than to the actual **Bill of Rights**: it declares principles and asserts claims against concentrated power, but it does not establish courts, enforcement mechanisms, or procedures for redress. The Blueprint was always non-binding guidance; the recent rescission removed even that declarative scaffolding from federal AI policy.
+Sociologist [Alondra Nelson](https://www.ias.edu/sss/faculty/nelson){target=_blank} — who led the Blueprint's development as acting director of OSTP — argues in [*A civic grammar for AI rights*](https://www.science.org/doi/10.1126/science.aeh7153){target=_blank} (Science, 2026) that the Blueprint drew its name from the first ten amendments to the U.S. Constitution, but in structural terms resembles a different founding document: the **Declaration of Independence**.
 
-Nelson distinguishes the public Blueprint from **corporate "AI constitutions"** — internal training and alignment specifications written by AI companies for their own models. Anthropic's *Claude Constitution* is the canonical example. These corporate documents are not negotiated with the publics affected by AI deployments, can be revised by company fiat, and recent versions have quietly removed references to international human rights agreements — and with them protections for personal liberty, freedom of religion, and intellectual property that earlier versions included.
+> "Unlike the Bill of Rights, the Blueprint does not establish courts or enforcement mechanisms. It does not create procedures for redress. It declares. It states principles and claims rights against a concentration of power that most Americans cannot meaningfully constrain through existing institutions or processes."
 
-The deeper question Nelson raises is *who gets to author the foundational documents that govern AI* — companies, or publics? She frames the public response as a **"civic grammar"** — a shared vocabulary of rights claims (privacy, non-discrimination, due process, notice, recourse) that the public has built up over decades and can now extend to AI systems. For the philosophical framing in more depth, see [AI Constitutions and Bills of Rights](ethics.md#ai-constitutions-and-bills-of-rights) in the Ethics lesson.
+The five principles, Nelson argues, are statements of values — "social expectations, stated in the vocabulary Americans reach for when they want to contest power: Patients' Bill of Rights, Consumer Bill of Rights, Tenants' Bill of Rights, Workers' Bill of Rights, Taxpayers' Bill of Rights." The Blueprint extended that civic grammar to algorithmic systems.
+
+Nelson distinguishes the public Blueprint from **corporate "AI constitutions"** — internal training and alignment specifications written by AI companies for their own models. Anthropic's *Claude Constitution* is the canonical example. These corporate documents are not negotiated with the publics affected by AI deployments, can be revised by company fiat, and recent versions have quietly removed references to international human rights agreements. The deeper question, Nelson asks, is *who gets to author the foundational documents that govern AI* — companies, or publics? For the philosophical framing in depth (T. H. Marshall's social-citizenship framework, the diffusion mechanism, the limits of rights talk), see [AI Constitutions and Bills of Rights](ethics.md#ai-constitutions-and-bills-of-rights) in the Ethics lesson.
+
+### The Blueprint's "second life": cross-partisan diffusion
+
+Although rescinded at the federal level, the Blueprint, in Nelson's words, "has done what its metaphor suggests blueprints do: it has been built upon." State legislatures, governors, and advocacy organizations have produced their own AI bills of rights drawing directly from the five principles — often across explicitly opposed political coalitions:
+
+- **Connecticut (2023):** Democratic Governor Ned Lamont signed legislation directing state policy-makers to develop their own AI Bill of Rights.
+- **Oklahoma (2024):** The Republican-controlled House of Representatives introduced and passed an AI Bill of Rights, though it was not ultimately codified into law.
+- **Florida (2025):** Republican Governor Ron DeSantis pushed for an AI Bill of Rights through executive action and twice backed Florida Senate Bill 482, the "Artificial Intelligence Bill of Rights," which would codify several Blueprint principles into Florida law. The bill was blocked in the Florida House, where the Speaker aligned with the Trump administration's effort to prevent states from regulating AI.
+- **Student AI Bill of Rights (2026):** The National Student Legal Defense Network released a Student AI Bill of Rights.
+
+These actors did not coordinate. As Nelson puts it: "What the actors share is a vocabulary and a common perspective that AI is reshaping people's lives without their consultation." The driver of the diffusion is not relational but conceptual — what sociologists David Strang and John Meyer describe as alignment among "weakly related actors" through abstract typologies that travel "as a strategy for making sense of the world."
+
+### International convergence
+
+Legal scholar Yuval Shany has surveyed international standard-setting instruments — the [EU AI Act](https://artificialintelligenceact.eu/){target=_blank}, the [Council of Europe Framework Convention on AI](https://www.coe.int/en/web/artificial-intelligence/the-framework-convention-on-artificial-intelligence){target=_blank}, the United Nations Global Digital Compact, and national legislation in South Korea and Italy — and finds they coalesce around the same protections as the Blueprint: **non-discrimination, transparency, data privacy, and human alternatives**. The pattern predates the Blueprint: the EU's General Data Protection Regulation (GDPR) established data-protection rights nearly a decade earlier. The "bill of rights" frame is American; the underlying rights-claim convergence is global.
+
+### From declaration to enforcement
+
+Nelson is direct about what civic grammar alone cannot deliver. The harder labor that remains is "translating the grammar of rights into the standards, audit protocols, and enforcement mechanisms that give those sentences force." The institutional models exist:
+
+- **Algorithmic impact assessments** required before AI systems are shipped.
+- **Standardized evaluation methods** for detecting algorithmic risk and harm.
+- **Independent audit frameworks** that subject deployed systems to outside scrutiny.
+
+What is missing, in Nelson's account, is the political will to extend existing accountability frameworks to a domain that has so far resisted them — and the institutional coalitions, not just the vocabulary, required to deliver the principles the Blueprint declared.
 
 !!! info "Sources and further reading"
 
     - Alondra Nelson, [*A civic grammar for AI rights*](https://www.science.org/doi/10.1126/science.aeh7153){target=_blank}, *Science* (2026). DOI: 10.1126/science.aeh7153
     - Alondra Nelson, [Bluesky thread on these principles](https://bsky.app/profile/alondra.bsky.social/post/3mltfqoc7ok2y){target=_blank}
     - [Blueprint for an AI Bill of Rights](https://bidenwhitehouse.archives.gov/ostp/ai-bill-of-rights/){target=_blank} (White House OSTP, October 2022, archived)
+    - [EO 14110: Safe, Secure, and Trustworthy AI](https://www.federalregister.gov/documents/2023/11/01/2023-24283/safe-secure-and-trustworthy-development-and-use-of-artificial-intelligence){target=_blank} (Biden, October 2023, rescinded January 2025)
+    - [Removing Barriers to American Leadership in AI](https://www.whitehouse.gov/presidential-actions/2025/01/removing-barriers-to-american-leadership-in-artificial-intelligence/){target=_blank} (Trump, January 2025)
     - Anthropic, [Claude's Constitution](https://www.anthropic.com/news/claudes-constitution){target=_blank}
 
 ## Current Legislation

--- a/docs/legal.md
+++ b/docs/legal.md
@@ -120,14 +120,38 @@ In response to the rapid rise of generative AI, specifically GPTs, new agreement
 | **Framework Convention on Artificial Intelligence** | September 5, 2024 | United States, United Kingdom, European Union, Andorra, Georgia, Iceland, Norway, Republic of Moldova, San Marino, Israel | The first legally binding international treaty on AI, aiming to ensure AI activities are consistent with human rights, democracy, and the rule of law. | [Council of Europe](https://www.coe.int/en/web/artificial-intelligence/the-framework-convention-on-artificial-intelligence){target=_blank} |
 | **AI Alliance Network** | December 11, 2024 | Russia, BRICS countries (Brazil, China, India, South Africa), Serbia, Indonesia, and others | An initiative to develop AI collaboratively, focusing on joint research, regulation, and commercialization of AI products among member countries. | [Reuters](https://www.reuters.com/technology/artificial-intelligence/russia-teams-up-with-brics-create-ai-alliance-putin-says-2024-12-11/){target=_blank} |
 
+## Blueprint for an AI Bill of Rights
+
+The [**Blueprint for an AI Bill of Rights**](https://bidenwhitehouse.archives.gov/ostp/ai-bill-of-rights/){target=_blank} was released by the White House Office of Science and Technology Policy (OSTP) in October 2022. It proposed five principles to guide the design, development, and deployment of automated systems:
+
+1. **Safe and Effective Systems** — protection from unsafe or ineffective systems.
+2. **Algorithmic Discrimination Protections** — equitable design and use of automated systems.
+3. **Data Privacy** — protection from abusive data practices, with agency over how your data is used.
+4. **Notice and Explanation** — knowing when an automated system is being used and how/why it affects you.
+5. **Human Alternatives, Consideration, and Fallback** — the ability to opt out and reach a human alternative when an automated system fails or causes harm.
+
+The companion [Executive Order on Safe, Secure, and Trustworthy Development and Use of Artificial Intelligence](https://www.federalregister.gov/documents/2023/11/01/2023-24283/safe-secure-and-trustworthy-development-and-use-of-artificial-intelligence){target=_blank} (October 2023) operationalized parts of this framework for federal agencies. **Both the Blueprint and the Executive Order have been rescinded by the current administration.**
+
+### Constitution vs. Bill of Rights vs. Declaration of Independence
+
+Sociologist [Alondra Nelson](https://www.ias.edu/sss/faculty/nelson){target=_blank} — who led the Blueprint's development as acting director of OSTP — has argued in [*A civic grammar for AI rights*](https://www.science.org/doi/10.1126/science.aeh7153){target=_blank} (Science, 2026) that the Blueprint is structurally closer to the **Declaration of Independence** than to the actual **Bill of Rights**: it declares principles and asserts claims against concentrated power, but it does not establish courts, enforcement mechanisms, or procedures for redress. The Blueprint was always non-binding guidance; the recent rescission removed even that declarative scaffolding from federal AI policy.
+
+Nelson distinguishes the public Blueprint from **corporate "AI constitutions"** — internal training and alignment specifications written by AI companies for their own models. Anthropic's *Claude Constitution* is the canonical example. These corporate documents are not negotiated with the publics affected by AI deployments, can be revised by company fiat, and recent versions have quietly removed references to international human rights agreements — and with them protections for personal liberty, freedom of religion, and intellectual property that earlier versions included.
+
+The deeper question Nelson raises is *who gets to author the foundational documents that govern AI* — companies, or publics? She frames the public response as a **"civic grammar"** — a shared vocabulary of rights claims (privacy, non-discrimination, due process, notice, recourse) that the public has built up over decades and can now extend to AI systems. For the philosophical framing in more depth, see [AI Constitutions and Bills of Rights](ethics.md#ai-constitutions-and-bills-of-rights) in the Ethics lesson.
+
+!!! info "Sources and further reading"
+
+    - Alondra Nelson, [*A civic grammar for AI rights*](https://www.science.org/doi/10.1126/science.aeh7153){target=_blank}, *Science* (2026). DOI: 10.1126/science.aeh7153
+    - Alondra Nelson, [Bluesky thread on these principles](https://bsky.app/profile/alondra.bsky.social/post/3mltfqoc7ok2y){target=_blank}
+    - [Blueprint for an AI Bill of Rights](https://bidenwhitehouse.archives.gov/ostp/ai-bill-of-rights/){target=_blank} (White House OSTP, October 2022, archived)
+    - Anthropic, [Claude's Constitution](https://www.anthropic.com/news/claudes-constitution){target=_blank}
+
 ## Current Legislation
 
 [National Conference of State Legislatures (NCSL) Artificial Intelligence Legislation Database](https://www.ncsl.org/financial-services/artificial-intelligence-legislation-database){target=_blank}
 
-
-The previous administration had proposed a ["Blueprint for an AI Bill of Rights"](https://bidenwhitehouse.archives.gov/ostp/ai-bill-of-rights/){target=_blank}, and executive order around the ["Safe, Secure, and Trustworthy Development and Use of Artificial Intelligence"](https://www.federalregister.gov/documents/2023/11/01/2023-24283/safe-secure-and-trustworthy-development-and-use-of-artificial-intelligence){target=_blank} which is now rescinded. 
-
-The current administration has instead focused most of its efforts on executive orders related to AI and federal agencies. [Pending legislation](https://www.newsweek.com/trump-constitutional-crisis-ai-2076230){target=_blank} would ban states' ability to enforce AI regulations. 
+The current administration has focused most of its efforts on executive orders related to AI and federal agencies. [Pending legislation](https://www.newsweek.com/trump-constitutional-crisis-ai-2076230){target=_blank} would ban states' ability to enforce AI regulations. 
 
 
 !!! Tip "2025 Executive Orders"

--- a/docs/vibe.md
+++ b/docs/vibe.md
@@ -151,7 +151,7 @@ Browser-based version of Claude Code providing AI pair programming capabilities 
 
 :material-web: :material-license: :material-api:
 
-OpenAI's ChatGPT Plus and Team tiers include Code Interpreter (Advanced Data Analysis) for executing Python code, analyzing data, and generating visualizations directly in the browser.
+OpenAI's ChatGPT runs a sandboxed Python environment for executing code, analyzing data, and generating visualizations directly in the browser. Available on Plus and Team tiers.
 
 #### [:simple-google: Google Gemini](https://gemini.google.com){target=_blank}
 


### PR DESCRIPTION
## Summary

Five small, scoped commits on top of the already-merged code.md cut (PR #13). Each commit is self-contained.

**`e654cd0` — Drop OpenAI "Code Interpreter" branding from remaining mentions**
Three rewrites using functional descriptions instead of the OpenAI product name: `vibe.md` ChatGPT entry → "sandboxed Python environment"; `chatgpt.md` advanced-feature bullet → "Sandboxed Python"; `ai_sandboxes.md` Medium-risk examples → "ChatGPT, Claude Artifacts, Gemini sandboxes; Google Colab".

**`1930e65` — Image-generation refresh + Nano Banana synthetic-data example + Gemini in Chrome**
`choose.md` image-gen table and "Image Generation Models" block updated for May 2026 leaders (Nano Banana 2, GPT Image 1.5/2, Imagen 4, FLUX 1.1 Pro / 2 Pro, Ideogram v3, SD 3.5, Midjourney v7). Drops Imagine with Meta and Craiyon. Adds a worked example: *Synthetic data for downstream model training: storm damage assessment from drone imagery* — five-step workflow with concrete Nano Banana prompts, methodological caveats, and cross-links to xBD/LADI labeled real-disaster datasets. Adds Google Chrome + Gemini to the Agentic Browsers table with three plan tiers reflecting the January 2026 Auto Browse launch.

**`b16fabc` — Mark Sora as discontinued across docs**
OpenAI announced Sora's discontinuation on March 24, 2026 (web/app shut down April 26, 2026; API sunsets September 24, 2026). All 11 Sora references updated across `choose.md`, `chatgpt.md`, and `ai_landscape.md`. Migration pointers (Veo 3, Runway, Kling) added. ChatGPT tier feature bullets for "Sora credits" removed. Historical/pedagogical references (e.g. Sora as a world-models example) keep Sora but note the discontinuation context.

**`f9440a7` — Add AI Constitutions and Bill of Rights sections (initial)**
New parallel sections in `ethics.md` and `legal.md` based on Alondra Nelson's "A civic grammar for AI rights" (Science, 2026, DOI: 10.1126/science.aeh7153). Cross-linked.

**`f8e72da` — Expand AI Constitutions sections with full Nelson framing**
Working from the full article text: adds T. H. Marshall's social-citizenship framework, Strang & Meyer's "weakly related actors" diffusion mechanism, the Jill Lepore quote, concrete state-level diffusion examples (CT 2023 / OK 2024 / FL SB 482 2025 / Student AI Bill of Rights 2026), Yuval Shany's international-convergence analysis, the "From declaration to enforcement" subsection with concrete institutional models (algorithmic impact assessments, evaluation methods, audit frameworks), and a "Limits of rights talk" subsection.

## Test plan

- [ ] `Publish docs via GitHub` workflow completes successfully on merge
- [ ] `/choose/#image-generation-models` shows the new Nano Banana entries and the synthetic-data worked example
- [ ] `/choose/#agentic-browsers-ai-powered-web-browsers` shows the Google Chrome + Gemini row
- [ ] `/chatgpt/` no longer offers Sora credits as a tier benefit; heads-up note explains discontinuation
- [ ] `/ethics/#ai-constitutions-and-bills-of-rights` renders, cross-link to legal.md anchor works
- [ ] `/legal/#blueprint-for-an-ai-bill-of-rights` renders, cross-link to ethics.md anchor works
- [ ] No broken `code.md` or `Code Interpreters` link warnings in build output

https://claude.ai/code/session_016V7qR3rPU4vy5ogRPhib8X

---
_Generated by [Claude Code](https://claude.ai/code/session_016V7qR3rPU4vy5ogRPhib8X)_