### PR TITLE
Add Presentations tab under Tutorials with four UA PH&amp;AI slide decks

### DIFF
--- a/docs/tutorials/presentations/deck-stage.js
+++ b/docs/tutorials/presentations/deck-stage.js
@@ -1,0 +1,232 @@
+/**
+ * deck-stage.js — minimal slide-deck shell custom element
+ *
+ * Usage:
+ *   <deck-stage width="1920" height="1080">
+ *     <section>slide 1</section>
+ *     <section>slide 2</section>
+ *   </deck-stage>
+ *
+ * Features:
+ *   - Fits the design canvas (default 1920x1080) into the viewport, preserving aspect ratio
+ *   - Keyboard nav: arrows, PgUp/Dn, Home/End, space, Enter, Backspace, f for fullscreen
+ *   - Click-nav: right half of slide advances, left half goes back
+ *   - Slide-count overlay (bottom-right)
+ *   - Persistence: URL hash (#7) and localStorage (per-deck path)
+ *   - Print-to-PDF: one slide per page at the design dimensions
+ *   - postMessage hook: emits {slideIndexChanged: N} to window.parent for speaker-notes windows
+ */
+
+class DeckStage extends HTMLElement {
+  constructor() {
+    super();
+    this._slides = [];
+    this._idx = 0;
+    this._w = 1920;
+    this._h = 1080;
+    this._lsKey = null;
+  }
+
+  connectedCallback() {
+    this._w = parseInt(this.getAttribute('width'), 10) || 1920;
+    this._h = parseInt(this.getAttribute('height'), 10) || 1080;
+    this._lsKey = 'deck-stage:' + location.pathname;
+
+    // Host occupies the viewport
+    Object.assign(this.style, {
+      display: 'block',
+      position: 'fixed',
+      inset: '0',
+      overflow: 'hidden',
+      background: '#000',
+      zIndex: '0',
+    });
+
+    // Canvas at design size; transform-scaled to fit
+    this._canvas = document.createElement('div');
+    this._canvas.className = 'deck-canvas';
+    Object.assign(this._canvas.style, {
+      position: 'absolute',
+      top: '50%',
+      left: '50%',
+      width: this._w + 'px',
+      height: this._h + 'px',
+      transformOrigin: '0 0',
+    });
+
+    // Pull existing <section> children into the canvas
+    this._slides = Array.from(this.querySelectorAll(':scope > section'));
+    this._slides.forEach((s, i) => {
+      Object.assign(s.style, {
+        position: 'absolute',
+        inset: '0',
+        width: this._w + 'px',
+        height: this._h + 'px',
+        display: 'none',
+      });
+      if (!s.hasAttribute('data-screen-label')) {
+        s.setAttribute('data-screen-label', String(i + 1).padStart(2, '0'));
+      }
+      this._canvas.appendChild(s);
+    });
+    this.appendChild(this._canvas);
+
+    // Slide counter overlay
+    this._counter = document.createElement('div');
+    this._counter.className = 'deck-counter';
+    this._counter.setAttribute('aria-hidden', 'true');
+    Object.assign(this._counter.style, {
+      position: 'absolute',
+      bottom: '14px',
+      right: '18px',
+      color: 'rgba(255,255,255,0.55)',
+      font: '500 13px/1 "JetBrains Mono", ui-monospace, monospace',
+      letterSpacing: '0.14em',
+      textTransform: 'uppercase',
+      pointerEvents: 'none',
+      zIndex: '10',
+    });
+    this.appendChild(this._counter);
+
+    // Bind events
+    this._onResize = this._scale.bind(this);
+    window.addEventListener('resize', this._onResize);
+    this._onKey = this._handleKey.bind(this);
+    window.addEventListener('keydown', this._onKey);
+    this._onHash = () => this._readHash();
+    window.addEventListener('hashchange', this._onHash);
+
+    // Tap navigation on the canvas itself
+    this._canvas.addEventListener('click', (e) => {
+      const rect = this._canvas.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      if (x > rect.width / 2) this._go(this._idx + 1);
+      else this._go(this._idx - 1);
+    });
+
+    // Initial state: URL hash > stored > slide 0
+    if (!this._readHash()) {
+      if (!this._readStored()) this._go(0);
+    }
+    this._scale();
+  }
+
+  disconnectedCallback() {
+    window.removeEventListener('resize', this._onResize);
+    window.removeEventListener('keydown', this._onKey);
+    window.removeEventListener('hashchange', this._onHash);
+  }
+
+  _scale() {
+    const sx = window.innerWidth / this._w;
+    const sy = window.innerHeight / this._h;
+    const s = Math.min(sx, sy);
+    this._canvas.style.transform = 'translate(-50%, -50%) scale(' + s + ')';
+  }
+
+  _handleKey(e) {
+    if (e.metaKey || e.ctrlKey || e.altKey) return;
+    let handled = true;
+    switch (e.key) {
+      case 'ArrowRight':
+      case 'ArrowDown':
+      case 'PageDown':
+      case ' ':
+      case 'Enter':
+        this._go(this._idx + 1);
+        break;
+      case 'ArrowLeft':
+      case 'ArrowUp':
+      case 'PageUp':
+      case 'Backspace':
+        this._go(this._idx - 1);
+        break;
+      case 'Home':
+        this._go(0);
+        break;
+      case 'End':
+        this._go(this._slides.length - 1);
+        break;
+      case 'f':
+      case 'F':
+        if (document.fullscreenElement) document.exitFullscreen();
+        else document.documentElement.requestFullscreen();
+        break;
+      default:
+        handled = false;
+    }
+    if (handled) e.preventDefault();
+  }
+
+  _readHash() {
+    const m = /^#(\d+)$/.exec(location.hash);
+    if (m) {
+      const i = parseInt(m[1], 10) - 1;
+      if (i >= 0 && i < this._slides.length) {
+        this._go(i, true);
+        return true;
+      }
+    }
+    return false;
+  }
+
+  _readStored() {
+    try {
+      const v = parseInt(localStorage.getItem(this._lsKey), 10);
+      if (!Number.isNaN(v) && v >= 0 && v < this._slides.length) {
+        this._go(v);
+        return true;
+      }
+    } catch (_) {}
+    return false;
+  }
+
+  _go(i, skipHash) {
+    if (this._slides.length === 0) return;
+    i = Math.max(0, Math.min(this._slides.length - 1, i));
+    if (this._slides[this._idx]) this._slides[this._idx].style.display = 'none';
+    this._idx = i;
+    this._slides[this._idx].style.display = '';
+    this._counter.textContent = (i + 1) + ' / ' + this._slides.length;
+    try { localStorage.setItem(this._lsKey, String(i)); } catch (_) {}
+    if (!skipHash) {
+      history.replaceState(null, '', '#' + (i + 1));
+    }
+    if (window.parent !== window) {
+      window.parent.postMessage({ slideIndexChanged: i }, '*');
+    }
+  }
+}
+
+// Print stylesheet: show every slide stacked, one per page at design size
+const printStyle = document.createElement('style');
+printStyle.textContent = `
+@media print {
+  html, body { background: white !important; }
+  deck-stage {
+    position: static !important;
+    display: block !important;
+    background: white !important;
+  }
+  deck-stage > .deck-canvas {
+    position: static !important;
+    transform: none !important;
+    width: 1920px !important;
+    height: auto !important;
+  }
+  deck-stage > .deck-canvas > section {
+    display: block !important;
+    position: relative !important;
+    inset: auto !important;
+    width: 1920px !important;
+    height: 1080px !important;
+    page-break-after: always;
+    page-break-inside: avoid;
+  }
+  deck-stage > .deck-counter { display: none !important; }
+  @page { size: 1920px 1080px; margin: 0; }
+}
+`;
+document.head.appendChild(printStyle);
+
+customElements.define('deck-stage', DeckStage);

--- a/docs/tutorials/presentations/ethics-and-environmental-impact.html
+++ b/docs/tutorials/presentations/ethics-and-environmental-impact.html
@@ -1,0 +1,1903 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>Ethics &amp; Environmental Impact — Panel · UA PH&amp;AI 2026</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Manrope:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+<script src="deck-stage.js"></script>
+<style>
+  :root {
+    --ua-blue:        #0C234B;
+    --ua-blue-deep:   #07173a;
+    --ua-blue-mid:    #1b3870;
+    --ua-red:         #AB0520;
+    --ua-red-bright:  #c8102e;
+    --cream:          #f7f4ee;
+    --cream-warm:     #efe9dc;
+    --paper:          #fbfaf6;
+    --ink:            #161616;
+    --ink-soft:       #2a2a2a;
+    --mute:           #6b6b6b;
+    --rule:           #d8d2c4;
+    --code-bg:        #0f1623;
+    --code-fg:        #e6edf3;
+
+    --pad-x:          110px;
+    --pad-top:        96px;
+    --pad-bottom:     90px;
+  }
+
+  html, body { margin: 0; padding: 0; background: #000; }
+  body { font-family: 'Manrope', system-ui, sans-serif; color: var(--ink); }
+
+  deck-stage section {
+    box-sizing: border-box;
+    overflow: hidden;
+    background: var(--cream);
+    color: var(--ink);
+    font-family: 'Manrope', system-ui, sans-serif;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  .slide {
+    padding: var(--pad-top) var(--pad-x) var(--pad-bottom);
+    height: 100%;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+  }
+  .slide-dark { background: var(--ua-blue); color: var(--cream); }
+  .slide-paper { background: var(--paper); }
+  .slide-red { background: var(--ua-red); color: var(--cream); }
+
+  .tag {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    font-weight: 500;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--ua-red);
+  }
+  .slide-dark .tag { color: var(--cream-warm); opacity: 0.85; }
+  .slide-red .tag { color: var(--cream); opacity: 0.85; }
+
+  .title {
+    font-size: 72px;
+    font-weight: 700;
+    line-height: 1.02;
+    letter-spacing: -0.02em;
+    margin: 0;
+    text-wrap: balance;
+  }
+  .display {
+    font-size: 140px;
+    font-weight: 800;
+    line-height: 0.95;
+    letter-spacing: -0.035em;
+    margin: 0;
+    text-wrap: balance;
+  }
+  .subtitle {
+    font-size: 44px;
+    font-weight: 500;
+    line-height: 1.18;
+    color: var(--ink-soft);
+    margin: 0;
+    text-wrap: pretty;
+  }
+  .slide-dark .subtitle, .slide-red .subtitle { color: var(--cream-warm); }
+  .body {
+    font-size: 30px;
+    font-weight: 400;
+    line-height: 1.42;
+    color: var(--ink-soft);
+    margin: 0;
+    text-wrap: pretty;
+  }
+  .slide-dark .body { color: var(--cream-warm); }
+  .small {
+    font-size: 24px;
+    color: var(--mute);
+    line-height: 1.4;
+  }
+  .slide-dark .small { color: rgba(247,244,238,0.65); }
+  .mono { font-family: 'JetBrains Mono', monospace; }
+
+  .deck-header {
+    position: absolute;
+    top: 38px;
+    left: var(--pad-x);
+    right: var(--pad-x);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--mute);
+  }
+  .slide-dark .deck-header,
+  .slide-red .deck-header { color: rgba(247,244,238,0.55); }
+  .deck-header .lockup { display: flex; align-items: center; gap: 14px; }
+  .deck-header .ua-block {
+    display: inline-block;
+    width: 38px; height: 38px;
+    background: var(--ua-red);
+    color: var(--cream);
+    font-family: 'Manrope', sans-serif;
+    font-weight: 800;
+    font-size: 28px;
+    line-height: 38px;
+    text-align: center;
+    letter-spacing: -0.04em;
+  }
+  .slide-red .deck-header .ua-block { background: var(--cream); color: var(--ua-red); }
+
+  .deck-footer {
+    position: absolute;
+    bottom: 38px;
+    left: var(--pad-x);
+    right: var(--pad-x);
+    display: flex;
+    justify-content: space-between;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--mute);
+  }
+  .slide-dark .deck-footer,
+  .slide-red .deck-footer { color: rgba(247,244,238,0.5); }
+
+  .cols-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 80px; flex: 1; }
+  .cols-2-uneven { display: grid; grid-template-columns: 1.2fr 1fr; gap: 80px; flex: 1; }
+  .cols-3 { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 36px; flex: 1; }
+  .cols-4 { display: grid; grid-template-columns: 1fr 1fr 1fr 1fr; gap: 24px; }
+
+  .card {
+    background: var(--paper);
+    border: 1px solid var(--rule);
+    padding: 34px 36px;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+  }
+  .slide-dark .card {
+    background: rgba(255,255,255,0.04);
+    border-color: rgba(247,244,238,0.18);
+    color: var(--cream);
+  }
+  .card h4 {
+    font-size: 32px;
+    font-weight: 700;
+    margin: 0;
+    letter-spacing: -0.01em;
+    line-height: 1.05;
+  }
+  .card p {
+    font-size: 24px;
+    line-height: 1.4;
+    color: var(--ink-soft);
+    margin: 0;
+  }
+  .slide-dark .card p { color: var(--cream-warm); }
+  .card .kicker {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--ua-red);
+  }
+
+  .placeholder {
+    background:
+      repeating-linear-gradient(135deg,
+        rgba(12,35,75,0.06) 0,
+        rgba(12,35,75,0.06) 14px,
+        rgba(12,35,75,0.10) 14px,
+        rgba(12,35,75,0.10) 28px);
+    border: 1px solid var(--rule);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--ink-soft);
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    text-align: center;
+    padding: 24px;
+    box-sizing: border-box;
+  }
+
+  .section-slide {
+    padding: var(--pad-top) var(--pad-x) var(--pad-bottom);
+    height: 100%;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    position: relative;
+  }
+  .section-slide .part-num {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 28px;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    opacity: 0.7;
+    margin-bottom: 36px;
+  }
+  .section-slide .section-title {
+    font-size: 160px;
+    font-weight: 800;
+    line-height: 0.92;
+    letter-spacing: -0.035em;
+    margin: 0;
+    text-wrap: balance;
+  }
+  .section-slide .section-sub {
+    font-size: 36px;
+    font-weight: 400;
+    line-height: 1.3;
+    max-width: 1100px;
+    margin-top: 36px;
+    opacity: 0.85;
+  }
+
+  .title-slide {
+    height: 100%;
+    box-sizing: border-box;
+    padding: var(--pad-top) var(--pad-x) var(--pad-bottom);
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    position: relative;
+  }
+  .title-slide .grid-bg {
+    position: absolute; inset: 0;
+    background-image:
+      linear-gradient(rgba(247,244,238,0.05) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(247,244,238,0.05) 1px, transparent 1px);
+    background-size: 80px 80px;
+    pointer-events: none;
+  }
+  .title-slide-content {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 60px;
+  }
+
+  .step-label {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--ua-red);
+    margin-bottom: 18px;
+  }
+
+  table.surfaces {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 26px;
+  }
+  table.surfaces th, table.surfaces td {
+    text-align: left;
+    padding: 18px 16px;
+    border-bottom: 1px solid var(--rule);
+    vertical-align: top;
+  }
+  table.surfaces th {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--mute);
+    font-weight: 500;
+    border-bottom: 2px solid var(--ink);
+  }
+  table.surfaces td.tool {
+    font-weight: 700;
+    color: var(--ink);
+    font-size: 26px;
+  }
+  table.surfaces td.kind {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    color: var(--ua-red);
+    letter-spacing: 0.04em;
+  }
+  table.surfaces td.desc { color: var(--ink-soft); font-size: 24px; line-height: 1.35; }
+
+  .stack { display: flex; flex-direction: column; gap: 0; }
+  .stack-row {
+    display: grid;
+    grid-template-columns: 280px 1fr;
+    gap: 40px;
+    padding: 24px 0;
+    border-bottom: 1px solid var(--rule);
+    align-items: baseline;
+  }
+  .stack-row:last-child { border-bottom: none; }
+  .stack-row .label {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    color: var(--ua-red);
+  }
+  .stack-row .val {
+    font-size: 28px;
+    color: var(--ink-soft);
+    line-height: 1.35;
+  }
+  .stack-row .val strong { color: var(--ink); font-weight: 700; }
+
+  /* Capability blocks */
+  .cap-block {
+    border: 1px solid var(--rule);
+    background: var(--paper);
+    padding: 32px 32px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    min-height: 280px;
+  }
+  .cap-block .icon-letter {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 48px;
+    font-weight: 700;
+    color: var(--ua-red);
+    letter-spacing: -0.02em;
+  }
+  .cap-block h5 {
+    font-size: 28px;
+    font-weight: 700;
+    margin: 0;
+    line-height: 1.1;
+  }
+  .cap-block p {
+    font-size: 24px;
+    line-height: 1.4;
+    color: var(--ink-soft);
+    margin: 0;
+  }
+
+  /* Quote callout */
+  .pullquote {
+    font-size: 44px;
+    line-height: 1.25;
+    font-weight: 500;
+    letter-spacing: -0.01em;
+    color: var(--ink);
+    text-wrap: pretty;
+  }
+  .slide-dark .pullquote { color: var(--cream); }
+  .pullquote::before {
+    content: "\201C";
+    font-family: 'Manrope', sans-serif;
+    font-size: 100px;
+    line-height: 0.5;
+    color: var(--ua-red);
+    vertical-align: -22px;
+    margin-right: 12px;
+  }
+  .attrib {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--mute);
+    margin-top: 32px;
+  }
+  .slide-dark .attrib { color: rgba(247,244,238,0.6); }
+
+  /* Safety stack rows */
+  .safety-row {
+    display: grid;
+    grid-template-columns: 60px 1fr 2.2fr;
+    gap: 36px;
+    padding: 22px 0;
+    border-bottom: 1px solid var(--rule);
+    align-items: baseline;
+  }
+  .safety-row:last-child { border-bottom: none; }
+  .safety-row .n {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    color: var(--ua-red);
+    letter-spacing: 0.06em;
+  }
+  .safety-row .h {
+    font-size: 30px;
+    font-weight: 700;
+    color: var(--ink);
+    letter-spacing: -0.01em;
+    line-height: 1.15;
+  }
+  .safety-row .d {
+    font-size: 24px;
+    color: var(--ink-soft);
+    line-height: 1.4;
+  }
+
+  /* Compare panel */
+  .compare {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 36px;
+    flex: 1;
+  }
+  .compare-col {
+    background: var(--paper);
+    border: 1px solid var(--rule);
+    padding: 36px 38px 42px;
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+  }
+  .compare-col.alt { border-top: 8px solid var(--ua-blue); }
+  .compare-col.gov { border-top: 8px solid var(--ua-red); }
+  .compare-col .label {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--ua-red);
+  }
+  .compare-col.alt .label { color: var(--ua-blue); }
+  .compare-col h3 {
+    font-size: 38px;
+    font-weight: 700;
+    line-height: 1.05;
+    letter-spacing: -0.01em;
+    margin: 0;
+  }
+  .compare-col p {
+    font-size: 24px;
+    line-height: 1.42;
+    color: var(--ink-soft);
+    margin: 0;
+  }
+  .compare-col ul {
+    margin: 0; padding: 0; list-style: none;
+    display: flex; flex-direction: column; gap: 12px;
+  }
+  .compare-col ul li {
+    font-size: 24px;
+    line-height: 1.35;
+    color: var(--ink-soft);
+    padding-left: 28px;
+    position: relative;
+  }
+  .compare-col ul li::before {
+    content: "›";
+    position: absolute; left: 0;
+    color: var(--ua-red);
+    font-weight: 700;
+  }
+  .compare-col.alt ul li::before { color: var(--ua-blue); }
+
+  /* Three-tier pyramid for Marshall */
+  .marshall {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    margin-top: 20px;
+  }
+  .marshall-row {
+    display: grid;
+    grid-template-columns: 220px 280px 1fr;
+    gap: 32px;
+    padding: 26px 0;
+    border-bottom: 1px solid var(--rule);
+    align-items: baseline;
+  }
+  .marshall-row:first-child { border-top: 2px solid var(--ink); }
+  .marshall-row .era {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    color: var(--mute);
+    letter-spacing: 0.08em;
+  }
+  .marshall-row .wave {
+    font-size: 32px;
+    font-weight: 700;
+    color: var(--ink);
+    letter-spacing: -0.01em;
+  }
+  .marshall-row .wave .sub {
+    display: block;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    color: var(--ua-red);
+    font-weight: 500;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    margin-top: 4px;
+  }
+  .marshall-row .desc {
+    font-size: 24px;
+    color: var(--ink-soft);
+    line-height: 1.4;
+  }
+  .marshall-row.hi { background: rgba(171,5,32,0.04); }
+
+  /* Numbered grid */
+  .num-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    gap: 32px;
+    margin-top: 50px;
+  }
+  .num-block {
+    border-top: 2px solid var(--ink);
+    padding-top: 22px;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+  }
+  .slide-dark .num-block { border-top-color: var(--cream); }
+  .num-block .num {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 28px;
+    color: var(--ua-red);
+    letter-spacing: 0.08em;
+  }
+  .num-block h4 {
+    font-size: 34px;
+    font-weight: 700;
+    margin: 0;
+    letter-spacing: -0.01em;
+    line-height: 1.1;
+  }
+  .num-block p {
+    font-size: 24px;
+    line-height: 1.4;
+    color: var(--ink-soft);
+    margin: 0;
+  }
+  .slide-dark .num-block p { color: var(--cream-warm); }
+
+  /* Encyclical card */
+  .encyclical {
+    display: grid;
+    grid-template-columns: 1fr 1.4fr;
+    gap: 60px;
+    align-items: stretch;
+  }
+  .encyclical-seal {
+    background: var(--ua-blue);
+    color: var(--cream);
+    padding: 48px;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    gap: 32px;
+    position: relative;
+  }
+  .encyclical-seal .lat {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--cream-warm);
+  }
+  .encyclical-seal h3 {
+    font-size: 68px;
+    font-weight: 800;
+    margin: 0;
+    letter-spacing: -0.025em;
+    line-height: 0.95;
+    font-style: italic;
+  }
+  .encyclical-seal .meta {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    line-height: 1.55;
+    color: var(--cream-warm);
+    letter-spacing: 0.04em;
+  }
+  .encyclical-seal .meta strong { color: var(--cream); font-weight: 700; }
+
+  /* Discussion / panel question cards */
+  .q-block {
+    border: 1px solid var(--rule);
+    background: var(--paper);
+    padding: 34px 36px 36px;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+  }
+  .slide-dark .q-block {
+    background: rgba(255,255,255,0.04);
+    border-color: rgba(247,244,238,0.2);
+  }
+  .q-block .qnum {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    letter-spacing: 0.18em;
+    color: var(--ua-red);
+  }
+  .slide-dark .q-block .qnum { color: var(--ua-red-bright); }
+  .q-block h5 {
+    font-size: 28px;
+    font-weight: 700;
+    line-height: 1.2;
+    margin: 0;
+    letter-spacing: -0.01em;
+    text-wrap: balance;
+  }
+  .q-block p {
+    font-size: 24px;
+    line-height: 1.4;
+    color: var(--mute);
+    margin: 0;
+  }
+  .slide-dark .q-block h5 { color: var(--cream); }
+  .slide-dark .q-block p { color: rgba(247,244,238,0.65); }
+
+  /* Panelist roster */
+  .roster {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 28px;
+    margin-top: 24px;
+  }
+  .panelist {
+    border: 1px solid var(--rule);
+    background: var(--paper);
+    padding: 28px 30px;
+    display: grid;
+    grid-template-columns: 96px 1fr;
+    gap: 20px;
+    align-items: center;
+  }
+  .slide-dark .panelist {
+    background: rgba(255,255,255,0.04);
+    border-color: rgba(247,244,238,0.2);
+  }
+  .panelist .portrait {
+    width: 96px; height: 96px;
+    background:
+      repeating-linear-gradient(135deg,
+        rgba(12,35,75,0.10) 0,
+        rgba(12,35,75,0.10) 6px,
+        rgba(12,35,75,0.18) 6px,
+        rgba(12,35,75,0.18) 12px);
+    border: 1px solid var(--rule);
+  }
+  .slide-dark .panelist .portrait {
+    background:
+      repeating-linear-gradient(135deg,
+        rgba(247,244,238,0.06) 0,
+        rgba(247,244,238,0.06) 6px,
+        rgba(247,244,238,0.14) 6px,
+        rgba(247,244,238,0.14) 12px);
+    border-color: rgba(247,244,238,0.2);
+  }
+  .panelist .who {
+    font-size: 26px;
+    font-weight: 700;
+    color: var(--ink);
+    line-height: 1.1;
+    letter-spacing: -0.01em;
+  }
+  .panelist .role {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    color: var(--ua-red);
+    margin-top: 6px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+  .slide-dark .panelist .who { color: var(--cream); }
+
+  /* Footprint figure: stacked bars */
+  .footprint {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 60px;
+    flex: 1;
+    align-items: stretch;
+  }
+  .fp-card {
+    background: var(--paper);
+    border: 1px solid var(--rule);
+    padding: 36px 38px 40px;
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+  }
+  .fp-card .label {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    letter-spacing: 0.16em;
+    color: var(--ua-red);
+    text-transform: uppercase;
+  }
+  .fp-card h4 {
+    font-size: 36px;
+    font-weight: 700;
+    margin: 0;
+    letter-spacing: -0.01em;
+    line-height: 1.1;
+  }
+  .fp-card .figrow {
+    display: grid;
+    grid-template-columns: 160px 1fr;
+    align-items: center;
+    gap: 18px;
+  }
+  .fp-card .figrow .k {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    color: var(--mute);
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+  .fp-card .figrow .bar {
+    height: 22px;
+    background: var(--cream-warm);
+    border: 1px solid var(--rule);
+    position: relative;
+  }
+  .fp-card .figrow .bar .fill {
+    position: absolute; inset: 0 auto 0 0;
+    background: var(--ua-red);
+  }
+  .fp-card .figrow .bar.alt .fill { background: var(--ua-blue); }
+  .fp-card p {
+    font-size: 24px;
+    line-height: 1.42;
+    color: var(--ink-soft);
+    margin: 0;
+  }
+
+  /* Vocab band for transhumanism / posthumanism */
+  .vocab {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 28px;
+    margin-top: 40px;
+  }
+  .vocab-card {
+    border: 1px solid var(--rule);
+    background: var(--paper);
+    padding: 32px 34px;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+  }
+  .vocab-card .term {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--ua-red);
+  }
+  .vocab-card h4 {
+    font-size: 36px;
+    margin: 0;
+    line-height: 1.1;
+    letter-spacing: -0.01em;
+    font-weight: 700;
+  }
+  .vocab-card p {
+    font-size: 24px;
+    line-height: 1.42;
+    color: var(--ink-soft);
+    margin: 0;
+  }
+
+  /* Banner */
+  .warn-band {
+    background: var(--ua-red);
+    color: var(--cream);
+    padding: 28px 36px;
+    display: flex;
+    gap: 28px;
+    align-items: center;
+  }
+  .warn-band .label {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    flex: 0 0 auto;
+    border-right: 1px solid rgba(247,244,238,0.4);
+    padding-right: 28px;
+  }
+  .warn-band .msg { font-size: 26px; line-height: 1.35; }
+</style>
+</head>
+<body>
+
+<template id="__bundler_thumbnail" data-bg-color="#0C234B">
+  <svg viewBox="0 0 1200 800" xmlns="http://www.w3.org/2000/svg">
+    <rect width="1200" height="800" fill="#0C234B"/>
+    <rect x="470" y="250" width="120" height="120" fill="#AB0520"/>
+    <text x="530" y="345" font-family="Manrope, sans-serif" font-size="100" font-weight="800" fill="#f7f4ee" text-anchor="middle">A</text>
+    <text x="630" y="345" font-family="Manrope, sans-serif" font-size="100" font-weight="800" fill="#f7f4ee" text-anchor="start" opacity="0">.</text>
+    <text x="600" y="500" font-family="Manrope, sans-serif" font-size="56" font-weight="700" fill="#f7f4ee" text-anchor="middle">Ethics &amp; Environment</text>
+    <text x="600" y="560" font-family="monospace" font-size="28" letter-spacing="6" fill="#efe9dc" text-anchor="middle" opacity="0.7">UA PH&amp;AI · PANEL</text>
+  </svg>
+</template>
+
+<deck-stage width="1920" height="1080">
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       1 · TITLE
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="01 Title" class="slide-dark">
+    <div class="title-slide">
+      <div class="grid-bg"></div>
+      <div class="deck-header">
+        <div class="lockup">
+          <span class="ua-block">A</span>
+          <span>University of Arizona · BIO5 Institute</span>
+        </div>
+        <div>PH&amp;AI Summer School · Day 3 · Panel</div>
+      </div>
+
+      <div class="title-slide-content" style="margin-top: 40px;">
+        <div class="tag" style="font-size: 26px;">Closing Session · Panel Discussion</div>
+        <h1 class="display" style="font-size: 148px;">
+          Ethics &amp;<br>environmental<br>impact<span style="color: var(--ua-red-bright);">.</span>
+        </h1>
+        <p class="body" style="color: var(--cream-warm); font-size: 36px; max-width: 1300px;">
+          Who writes the rules — corporations or publics? What does an honest accounting
+          of the compute, the water, and the grid look like? An open conversation to
+          close the school.
+        </p>
+      </div>
+
+      <div class="title-slide-content" style="gap: 12px;">
+        <div style="background: rgba(247,244,238,0.4); height: 1px; max-width: 600px;"></div>
+        <div style="display: flex; justify-content: space-between; align-items: flex-end;">
+          <div>
+            <div style="color: var(--cream); font-weight: 600; font-size: 32px;">Moderated by Tyson Swetnam, PhD</div>
+            <div class="small mono" style="margin-top: 6px;">Associate Professor · BIO5 Institute</div>
+          </div>
+          <div class="mono small" style="text-align: right;">
+            Grand Challenges Research Building<br>
+            Tucson, AZ · June 2026
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       2 · PANEL FORMAT
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="02 Panel Format" class="slide-paper">
+    <div class="slide slide-paper">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · Ethics Panel</span></div>
+        <div>02 / Format</div>
+      </div>
+
+      <div class="tag" style="margin-top: 40px;">How This Session Runs</div>
+      <h2 class="title" style="margin-top: 20px; max-width: 1600px;">Sixty minutes. Three panelists. Six questions.</h2>
+
+      <div class="cols-3" style="margin-top: 70px; gap: 32px;">
+        <div class="cap-block">
+          <span class="icon-letter">10′</span>
+          <h5>Framing.</h5>
+          <p>Tyson sets the question, the vocabulary, the stakes. The slides that follow are the shared substrate — not the lecture.</p>
+        </div>
+        <div class="cap-block">
+          <span class="icon-letter">35′</span>
+          <h5>Panel.</h5>
+          <p>Three voices working through six prompts. Brief openings, then real conversation — disagreement welcome.</p>
+        </div>
+        <div class="cap-block">
+          <span class="icon-letter">15′</span>
+          <h5>Room.</h5>
+          <p>Open Q&amp;A. You've been reading and prompting for three days — bring the harder question, not the safe one.</p>
+        </div>
+      </div>
+
+      <div class="roster">
+        <div class="panelist">
+          <div class="portrait"></div>
+          <div>
+            <div class="who">Panelist 01</div>
+            <div class="role">Public Health · Ethics</div>
+          </div>
+        </div>
+        <div class="panelist">
+          <div class="portrait"></div>
+          <div>
+            <div class="who">Panelist 02</div>
+            <div class="role">Policy · Law</div>
+          </div>
+        </div>
+        <div class="panelist">
+          <div class="portrait"></div>
+          <div>
+            <div class="who">Panelist 03</div>
+            <div class="role">Sustainability · Compute</div>
+          </div>
+        </div>
+      </div>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>02 · FORMAT</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       3 · ETHICS OF AI vs ETHICAL AI
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="03 Ethics vs Ethical">
+    <div class="slide">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · Ethics Panel</span></div>
+        <div>03 / Two Questions</div>
+      </div>
+
+      <div class="tag" style="margin-top: 40px;">Two Different Questions That Sound The Same</div>
+      <h2 class="title" style="margin-top: 20px; max-width: 1600px;">"Ethics <em>of</em> AI" is not the same as "Ethical AI."</h2>
+
+      <div class="cols-2" style="margin-top: 80px; gap: 60px;">
+        <div class="card" style="border-left: 6px solid var(--ua-blue);">
+          <div class="kicker" style="color: var(--ua-blue);">Ethics of AI · principles</div>
+          <h4>What rules should govern these systems?</h4>
+          <p style="font-size: 26px;">An outside-in question. Regulations, declarations, constitutions, bills of rights. Asks who has standing, who decides, who is harmed, who is accountable.</p>
+        </div>
+        <div class="card" style="border-left: 6px solid var(--ua-red);">
+          <div class="kicker">Ethical AI · behavior</div>
+          <h4>How should this model act, right now?</h4>
+          <p style="font-size: 26px;">An inside-out question. Refusal, safety, fairness, alignment. Asks how the system itself behaves under pressure — what it says yes to and what it says no to.</p>
+        </div>
+      </div>
+
+      <p class="body" style="margin-top: 60px; max-width: 1600px; font-size: 28px;">
+        Most of today's panel lives in the first column. Most of what AI companies talk about lives in the second.
+        The gap between them is where most of the disagreement actually sits — <span style="font-weight: 700; color: var(--ink);">Siau &amp; Wang (2020)</span>.
+      </p>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>03 · TWO QUESTIONS</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       4 · HISTORY · DARTMOUTH 1956
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="04 Dartmouth 1956" class="slide-paper">
+    <div class="slide slide-paper">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · Ethics Panel</span></div>
+        <div>04 / History</div>
+      </div>
+
+      <div class="tag" style="margin-top: 40px;">Where The Field Began</div>
+      <h2 class="title" style="margin-top: 20px; max-width: 1600px;">Dartmouth, summer 1956. Seventy years of waiting for the room we're in.</h2>
+
+      <div class="cols-2-uneven" style="margin-top: 70px; gap: 70px; flex: 0 1 auto;">
+        <div class="placeholder" style="min-height: 460px; font-size: 24px;">
+          [ DROP-IN IMAGE ]<br><br>
+          Dartmouth Summer Research Project<br>
+          Group photo · 1956<br>
+          credit: IEEE Spectrum
+        </div>
+        <div style="display: flex; flex-direction: column; gap: 24px; justify-content: center;">
+          <p class="body" style="font-size: 28px;">
+            A small group of scientists gathered at Dartmouth for a Summer Research Project on Artificial Intelligence.
+            They coined the term. The field begins.
+          </p>
+          <p class="body" style="font-size: 28px;">
+            For the next seventy years AI lived mainly in <strong style="color: var(--ink);">science fiction</strong> and in a small
+            community of industry researchers and academics quietly building the digital infrastructure the modern systems would need.
+          </p>
+          <p class="body" style="font-size: 28px;">
+            What changed in the last three years isn't the idea — it's the infrastructure. The questions waiting from 1956
+            arrived all at once.
+          </p>
+        </div>
+      </div>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>04 · HISTORY</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       5 · INHERITED FRAMES · ASIMOV + TURING TRAP
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="05 Inherited Frames">
+    <div class="slide">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · Ethics Panel</span></div>
+        <div>05 / Inherited Frames</div>
+      </div>
+
+      <div class="tag" style="margin-top: 40px;">Two Frames We Inherited From The Twentieth Century</div>
+      <h2 class="title" style="margin-top: 20px; max-width: 1600px;">Useful, partial, and still load-bearing in 2026.</h2>
+
+      <div class="cols-2" style="margin-top: 70px; gap: 60px;">
+        <div class="card" style="border-left: 6px solid var(--ua-red); padding: 38px 40px;">
+          <div class="kicker">1942 · Asimov · "Do No Harm"</div>
+          <h4>The Three Laws of Robotics.</h4>
+          <p style="font-size: 26px;">
+            Asimov's framing — robots must not harm humans, must obey, must protect themselves — is fiction, not law.
+            But the deep instinct it encodes (<em>prevent harm to humans, by design</em>) shows up in every modern AI safety practice:
+            refusal training, red-teaming, evals.
+          </p>
+          <p style="font-size: 24px; color: var(--mute);">
+            The point isn't to apply the laws. The point is that the field still asks Asimov's question first.
+          </p>
+        </div>
+        <div class="card" style="border-left: 6px solid var(--ua-red); padding: 38px 40px;">
+          <div class="kicker">2022 · Brynjolfsson · The Turing Trap</div>
+          <h4>Human-like ≠ human-empowering.</h4>
+          <p style="font-size: 26px;">
+            The Turing Trap warns that pushing AI toward <em>imitation</em> of humans tends to <strong style="color: var(--ink);">replace</strong> workers
+            rather than augment them — driving wages down and concentrating economic and political power.
+          </p>
+          <p style="font-size: 24px; color: var(--mute);">
+            "More human-like" is not a self-evidently good design goal. The frame matters.
+          </p>
+        </div>
+      </div>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>05 · INHERITED FRAMES</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       6 · PART 1 · DIVIDER · TWO GRAMMARS
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="06 Part 1 Divider" class="slide-dark">
+    <div class="section-slide">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · Ethics Panel</span></div>
+        <div>Part 01 · Two Grammars</div>
+      </div>
+      <div>
+        <div class="part-num">Part 01</div>
+        <h2 class="section-title">Who writes<br>the rules<span style="color: var(--ua-red-bright);">?</span></h2>
+        <p class="section-sub">
+          Corporate AI constitutions and public AI bills of rights are doing very different work.
+          Alondra Nelson argues one of them is structurally insufficient.
+        </p>
+      </div>
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>06 · PART 01</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       7 · CORPORATE CONSTITUTIONS vs PUBLIC BILLS OF RIGHTS
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="07 Two Documents" class="slide-paper">
+    <div class="slide slide-paper">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · Ethics Panel</span></div>
+        <div>07 / Two Documents</div>
+      </div>
+
+      <div class="tag" style="margin-top: 40px;">Two Foundational Documents · Two Sources Of Legitimacy</div>
+      <h2 class="title" style="margin-top: 20px; max-width: 1600px;">A corporate constitution and a public bill of rights are not the same kind of object.</h2>
+
+      <div class="compare" style="margin-top: 56px;">
+        <div class="compare-col alt">
+          <div class="label">Type 01 · Corporate AI Constitution</div>
+          <h3>Internal training and alignment spec.</h3>
+          <p>The model developer's vision of how its own model should behave. Canonical example: a frontier-lab "constitution" document used in training.</p>
+          <ul>
+            <li>Written and revised by company fiat</li>
+            <li>Not negotiated with affected publics</li>
+            <li>Newer revisions can quietly remove references to international human-rights frameworks</li>
+            <li>Legitimacy comes from the company's own authority</li>
+          </ul>
+        </div>
+        <div class="compare-col gov">
+          <div class="label">Type 02 · Public AI Bill Of Rights</div>
+          <h3>Democratic rights claim against algorithmic power.</h3>
+          <p>Developed through public process. Canonical example: the White House OSTP <em>Blueprint for an AI Bill of Rights</em>, October 2022.</p>
+          <ul>
+            <li>Declares principles publics can extend to new institutions and new harms</li>
+            <li>Five principles: safety, discrimination protections, data privacy, notice/explanation, human alternatives</li>
+            <li>Force comes from democratic legitimacy and the surrounding legal infrastructure</li>
+            <li>Structurally closer to a <em>Declaration</em> than to a Bill — declares, but does not enforce</li>
+          </ul>
+        </div>
+      </div>
+
+      <p class="small" style="margin-top: 40px; max-width: 1700px; font-size: 24px;">
+        Source: Alondra Nelson, <em>A civic grammar for AI rights</em>, Science (2026). DOI 10.1126/science.aeh7153
+      </p>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>07 · TWO DOCUMENTS</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       8 · CIVIC GRAMMAR
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="08 Civic Grammar">
+    <div class="slide">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · Ethics Panel</span></div>
+        <div>08 / Civic Grammar</div>
+      </div>
+
+      <div class="tag" style="margin-top: 40px;">Nelson's Argument</div>
+      <h2 class="title" style="margin-top: 20px; max-width: 1600px;">A shared vocabulary for rights claims is moving across actors who agree on almost nothing else.</h2>
+
+      <div class="cols-2-uneven" style="margin-top: 60px; gap: 80px; flex: 0 1 auto;">
+        <div style="display: flex; flex-direction: column; justify-content: center;">
+          <p class="pullquote">
+            A <strong style="color: var(--ua-red);">civic grammar</strong> — non-discrimination, transparency, data privacy, notice, human alternatives — that has been traveling across jurisdictions, partisan lines, and institutional contexts.
+          </p>
+          <div class="attrib">Alondra Nelson · Science · 2026</div>
+        </div>
+        <div style="display: flex; flex-direction: column; gap: 22px; justify-content: center;">
+          <div class="card">
+            <div class="kicker">The pattern</div>
+            <p style="font-size: 25px;">
+              An American tradition — Patients', Consumer, Tenants', Workers', Taxpayers' Bills of Rights.
+              The AI Bill of Rights template is spreading the same way.
+            </p>
+          </div>
+          <div class="card" style="border-left: 6px solid var(--ua-red);">
+            <div class="kicker">The mechanism</div>
+            <p style="font-size: 25px;">
+              <strong style="color: var(--ink);">Institutional diffusion among weakly related actors</strong>
+              (Strang &amp; Meyer). Conceptual, not relational. Connecticut Democrats, Oklahoma Republicans, and a national student-advocacy network can adopt the same vocabulary because each, separately, met the same algorithmic harm.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>08 · CIVIC GRAMMAR</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       9 · MARSHALL · SOCIAL CITIZENSHIP
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="09 Marshall" class="slide-paper">
+    <div class="slide slide-paper">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · Ethics Panel</span></div>
+        <div>09 / Marshall</div>
+      </div>
+
+      <div class="tag" style="margin-top: 40px;">T. H. Marshall · Citizenship And Social Class · 1950</div>
+      <h2 class="title" style="margin-top: 16px; max-width: 1600px; font-size: 60px;">Rights expand in waves. AI rights map onto Marshall's <em>social</em> tier.</h2>
+
+      <div class="marshall">
+        <div class="marshall-row">
+          <div class="era">18th c.</div>
+          <div class="wave">Civil rights<span class="sub">Wave 01</span></div>
+          <div class="desc">Liberty of person, speech, faith, property. Individual freedoms against arbitrary state power.</div>
+        </div>
+        <div class="marshall-row">
+          <div class="era">19th c.</div>
+          <div class="wave">Political rights<span class="sub">Wave 02</span></div>
+          <div class="desc">The franchise. Participation in collective political authority. Universal suffrage as the long-running expansion.</div>
+        </div>
+        <div class="marshall-row hi">
+          <div class="era">20th c.</div>
+          <div class="wave">Social rights<span class="sub">Wave 03</span></div>
+          <div class="desc">Economic security and the conditions of participation. Entitlements against harms of industrial capitalism that civil-liberties frameworks could not address.</div>
+        </div>
+        <div class="marshall-row hi">
+          <div class="era">21st c. ?</div>
+          <div class="wave">AI rights<span class="sub">Nelson's argument</span></div>
+          <div class="desc">Entitlements against systems "that increasingly govern access to employment, credit, healthcare, housing, and education." Collective, diffuse, opaque harms. A social-citizenship response to algorithmic power.</div>
+        </div>
+      </div>
+
+      <p class="small" style="margin-top: 36px; max-width: 1700px; font-size: 24px;">
+        "Rights are never fully delivered at the moment of declaration. They are successively rearticulated by publics who attempt to hold institutions to commitments those institutions have not yet honored." — Nelson, paraphrasing Marshall.
+      </p>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>09 · MARSHALL</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       10 · LIMITS OF RIGHTS TALK
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="10 Limits Of Rights Talk">
+    <div class="slide">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · Ethics Panel</span></div>
+        <div>10 / Limits</div>
+      </div>
+
+      <div class="tag" style="margin-top: 40px;">What Civic Grammar Cannot Do On Its Own</div>
+      <h2 class="title" style="margin-top: 20px; max-width: 1600px;">Three failure modes Nelson is clear-eyed about.</h2>
+
+      <div class="stack" style="margin-top: 60px;">
+        <div class="safety-row">
+          <div class="n">01</div>
+          <div class="h">Accommodation can mimic transformation.</div>
+          <div class="d">A vocabulary that moves easily across partisan lines may have been "drained of the political content that gives rights claims their force." Crossing the aisle is not the same as biting.</div>
+        </div>
+        <div class="safety-row">
+          <div class="n">02</div>
+          <div class="h">Rights individualize structural problems.</div>
+          <div class="d">Frameworks built around individual claims often fail to address the collective and systemic nature of algorithmic harms. A model isn't biased against <em>you</em> — it's biased against a class you sit inside.</div>
+        </div>
+        <div class="safety-row">
+          <div class="n">03</div>
+          <div class="h">Declaration is not delivery.</div>
+          <div class="d">"Declarations of entitlement and their substantive delivery can remain decades apart, separated by the organized power of those who benefit from the status quo."</div>
+        </div>
+      </div>
+
+      <div class="warn-band" style="margin-top: 50px;">
+        <div class="label">Nelson's question</div>
+        <div class="msg">Will democratic institutions take this civic grammar seriously <em>before</em> the AI companies finish writing their own constitutions for us all?</div>
+      </div>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>10 · LIMITS</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       11 · THREE IMPERATIVES
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="11 Three Imperatives" class="slide-dark">
+    <div class="slide slide-dark">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · Ethics Panel</span></div>
+        <div>11 / Three Imperatives</div>
+      </div>
+
+      <div class="tag" style="margin-top: 40px; color: var(--cream-warm);">Field Theory · Daedalus · Winter/Spring 2026</div>
+      <h2 class="title" style="margin-top: 20px; max-width: 1600px; color: var(--cream);">Three things AI is, at the same time, for any field that studies it.</h2>
+
+      <div class="num-grid" style="margin-top: 70px;">
+        <div class="num-block">
+          <div class="num">01 · QUESTION</div>
+          <h4>AI as social-science question.</h4>
+          <p>Renewed attention to social theories of how technology, human experience, and social order are entangled. Weber on rationalization, Du Bois on technology and inequality, contemporary work on algorithmic governance.</p>
+        </div>
+        <div class="num-block">
+          <div class="num">02 · OBJECT</div>
+          <h4>AI as object of inquiry.</h4>
+          <p>The systems themselves merit study as social, political, and economic artifacts — not just engineering products. Training corpora, labor relations, ideological commitments, institutional effects.</p>
+        </div>
+        <div class="num-block">
+          <div class="num">03 · TOOL</div>
+          <h4>AI as method / tool.</h4>
+          <p>AI capabilities may transform — or upend — the practice of social investigation itself: large-scale text analysis, multimodal pattern detection, conversational interviewing at scale. Worth critical scrutiny, not uncritical adoption.</p>
+        </div>
+      </div>
+
+      <p class="small" style="margin-top: 60px; max-width: 1700px; font-size: 24px; color: rgba(247,244,238,0.65);">
+        Diagnostic use: when you read a piece of AI-ethics scholarship, ask which imperative it engages.
+        That often clarifies what kind of argument is being made — and what kind of counter-argument would land.
+      </p>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>11 · THREE IMPERATIVES</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       12 · PART 2 · DIVIDER · A MORAL RESPONSE
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="12 Part 2 Divider" class="slide-red">
+    <div class="section-slide">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · Ethics Panel</span></div>
+        <div>Part 02 · A Moral Response</div>
+      </div>
+      <div>
+        <div class="part-num">Part 02</div>
+        <h2 class="section-title">Magnifica<br>Humanitas.</h2>
+        <p class="section-sub">
+          May 2026. Pope Leo XIV's first encyclical places AI alongside the industrial
+          revolution — and arrives at the same conclusion as Nelson from a very different starting point.
+        </p>
+      </div>
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>12 · PART 02</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       13 · MAGNIFICA HUMANITAS · OVERVIEW
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="13 Magnifica Humanitas">
+    <div class="slide">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · Ethics Panel</span></div>
+        <div>13 / Encyclical</div>
+      </div>
+
+      <div class="tag" style="margin-top: 40px;">Pope Leo XIV · First Encyclical · 2026</div>
+      <h2 class="title" style="margin-top: 16px; max-width: 1600px; font-size: 60px;">Treats AI as the central moral question of the age. Signed on a deliberate date.</h2>
+
+      <div class="encyclical" style="margin-top: 60px;">
+        <div class="encyclical-seal">
+          <div class="lat">Encyclical · Lat. <em>Magnificent Humanity</em></div>
+          <h3>Magnifica<br>Humanitas</h3>
+          <div class="meta">
+            <strong>Signed</strong>  15 May 2026<br>
+            <strong>Published</strong>  25 May 2026<br>
+            <strong>Length</strong>  235 pp.<br>
+            <strong>Addressed</strong>  Catholics &amp; "every person of goodwill"
+          </div>
+        </div>
+        <div style="display: flex; flex-direction: column; gap: 26px; justify-content: center;">
+          <div class="card">
+            <div class="kicker">The date is the argument</div>
+            <p style="font-size: 26px;">
+              May 15, 2026 is the <strong style="color: var(--ink);">135th anniversary of Pope Leo XIII's <em>Rerum Novarum</em></strong>
+              (1891) — the foundational encyclical of modern Catholic social teaching, written for the dignity of workers
+              under the 19th-century industrial revolution. Leo XIV places AI explicitly alongside that disruption.
+            </p>
+          </div>
+          <div class="card" style="border-left: 6px solid var(--ua-red);">
+            <div class="kicker">A break with tradition</div>
+            <p style="font-size: 26px;">
+              Pope Leo personally presented the encyclical at the Vatican, alongside a co-founder of a frontier
+              AI lab. The first time a pontiff has presented an encyclical himself rather than delegating to cardinals —
+              a signal that the conversation is dialogic, not purely adversarial.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>13 · ENCYCLICAL</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       14 · CORE TEACHINGS — TRANS/POSTHUMANISM
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="14 Core Teachings" class="slide-paper">
+    <div class="slide slide-paper">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · Ethics Panel</span></div>
+        <div>14 / Core Teachings</div>
+      </div>
+
+      <div class="tag" style="margin-top: 40px;">The Center Of The Encyclical</div>
+      <h2 class="title" style="margin-top: 20px; max-width: 1600px;">The dignity of the human person is affirmed as infinite. Two ideologies are named.</h2>
+
+      <div class="vocab">
+        <div class="vocab-card" style="border-left: 6px solid var(--ua-red);">
+          <div class="term">Critique 01 · Transhumanism</div>
+          <h4>Engineering away human finitude.</h4>
+          <p>The project of using technology to overcome biological limits — aging, mortality, embodiment.
+          Leo XIV rejects the framing of human finitude as a <em>problem</em> to be solved.</p>
+        </div>
+        <div class="vocab-card" style="border-left: 6px solid var(--ua-red);">
+          <div class="term">Critique 02 · Posthumanism</div>
+          <h4>Blurring the human/machine line.</h4>
+          <p>The philosophical position that humans and machines are continuous, or that human distinctiveness is illusory.
+          Named as an active <strong style="color: var(--ink);">"anti-human vision"</strong> embedded in contemporary AI development —
+          not merely a speculative stance.</p>
+        </div>
+      </div>
+
+      <div class="stack" style="margin-top: 40px;">
+        <div class="stack-row" style="padding: 18px 0;">
+          <div class="label">Evaluation frame</div>
+          <div class="val" style="font-size: 26px;"><strong>Dignity of the person · Common good · Justice.</strong> The three principles against which any AI deployment is measured.</div>
+        </div>
+        <div class="stack-row" style="padding: 18px 0;">
+          <div class="label">Coverage</div>
+          <div class="val" style="font-size: 26px;">Education · economy · unemployment · work · human trafficking · war. The full social-impact terrain Catholic social teaching has historically addressed.</div>
+        </div>
+      </div>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>14 · CORE TEACHINGS</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       15 · CALLS TO ACTION
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="15 Calls To Action">
+    <div class="slide">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · Ethics Panel</span></div>
+        <div>15 / Calls To Action</div>
+      </div>
+
+      <div class="tag" style="margin-top: 40px;">From Doctrine To Demand</div>
+      <h2 class="title" style="margin-top: 20px; max-width: 1600px;">Two operational claims — and one rhetorical move that does work outside the Church.</h2>
+
+      <div class="cols-3" style="margin-top: 70px; gap: 36px;">
+        <div class="cap-block">
+          <span class="icon-letter">"</span>
+          <h5>Disarm AI.</h5>
+          <p>Withdraw AI from military applications and from purely economic interests. Direct it toward the common good. The framing is deliberately stark.</p>
+        </div>
+        <div class="cap-block">
+          <span class="icon-letter">§</span>
+          <h5>Regulate it.</h5>
+          <p>Stricter state and international regulation of AI companies. Not industry self-governance. The encyclical does not treat the two as substitutes.</p>
+        </div>
+        <div class="cap-block">
+          <span class="icon-letter">∀</span>
+          <h5>Address everyone.</h5>
+          <p>"Every person of goodwill" — the same rhetorical move <em>Laudato Si'</em> (2015, on climate) and <em>Antiqua et Nova</em> (2025, on AI) used to seek ethical common ground beyond doctrinal lines.</p>
+        </div>
+      </div>
+
+      <div class="warn-band" style="margin-top: 60px;">
+        <div class="label">Convergence</div>
+        <div class="msg">
+          Pope Leo and Alondra Nelson arrive at the same conclusion from very different starting points:
+          <strong>corporate self-governance is structurally insufficient as a source of legitimacy.</strong>
+        </div>
+      </div>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>15 · CALLS TO ACTION</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       16 · PART 3 · DIVIDER · INTERNATIONAL SCAFFOLDING
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="16 Part 3 Divider" class="slide-dark">
+    <div class="section-slide">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · Ethics Panel</span></div>
+        <div>Part 03 · International Scaffolding</div>
+      </div>
+      <div>
+        <div class="part-num">Part 03</div>
+        <h2 class="section-title">The frameworks<br>already on the<br>table.</h2>
+        <p class="section-sub">
+          Before we invent a new ethics for AI, an inventory: the declarations, principles,
+          and conventions you are already operating under whether you read them or not.
+        </p>
+      </div>
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>16 · PART 03</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       17 · INTERNATIONAL DECLARATIONS
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="17 Declarations" class="slide-paper">
+    <div class="slide slide-paper">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · Ethics Panel</span></div>
+        <div>17 / Declarations</div>
+      </div>
+
+      <div class="tag" style="margin-top: 28px;">A Working Map · Not Exhaustive</div>
+      <h2 class="title" style="margin-top: 12px; max-width: 1600px; font-size: 56px;">Major declarations and agreements you can name from memory.</h2>
+
+      <table class="surfaces" style="margin-top: 36px;">
+        <thead>
+          <tr>
+            <th>Document</th>
+            <th>Issuing body</th>
+            <th>Force</th>
+            <th>What it does</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td class="tool">Framework Convention on AI &amp; Human Rights</td>
+            <td class="desc">Council of Europe</td>
+            <td class="kind">Treaty</td>
+            <td class="desc">Binding international convention tying AI systems to human-rights, democracy, and rule-of-law obligations.</td>
+          </tr>
+          <tr>
+            <td class="tool">Recommendation on the Ethics of AI</td>
+            <td class="desc">UNESCO</td>
+            <td class="kind">Recommendation</td>
+            <td class="desc">First global standard-setting instrument on AI ethics, adopted by 193 member states.</td>
+          </tr>
+          <tr>
+            <td class="tool">OECD AI Principles · G20 endorsement</td>
+            <td class="desc">OECD · endorsed by G20</td>
+            <td class="kind">Principles</td>
+            <td class="desc">Trustworthy-AI principles widely adopted as a starting point for national strategies; signal of cross-bloc consensus.</td>
+          </tr>
+          <tr>
+            <td class="tool">Political Declaration on Responsible Military Use of AI &amp; Autonomy</td>
+            <td class="desc">U.S. State Dept. + co-signatories</td>
+            <td class="kind">Declaration</td>
+            <td class="desc">Norms for military AI: human accountability, legal review, controlled escalation.</td>
+          </tr>
+          <tr>
+            <td class="tool">Toronto Declaration</td>
+            <td class="desc">Amnesty Intl. + Access Now</td>
+            <td class="kind">Declaration</td>
+            <td class="desc">Machine learning, equality, and non-discrimination — a civil-society anchor for the Nelson framework.</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <p class="small" style="margin-top: 30px; max-width: 1700px; font-size: 24px;">
+        Panel prompt: which of these has any practical effect on what a public health researcher in Arizona actually does next Tuesday?
+      </p>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>17 · DECLARATIONS</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       18 · PART 4 · DIVIDER · ENVIRONMENTAL
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="18 Part 4 Divider" class="slide-red">
+    <div class="section-slide">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · Ethics Panel</span></div>
+        <div>Part 04 · Footprint</div>
+      </div>
+      <div>
+        <div class="part-num">Part 04</div>
+        <h2 class="section-title">The bill<br>nobody<br>itemized.</h2>
+        <p class="section-sub">
+          A frontier model has a body. Silicon, electricity, water, copper, land.
+          What an honest accounting of the environmental cost looks like — and where it lands.
+        </p>
+      </div>
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>18 · PART 04</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       19 · WHERE THE COST LANDS
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="19 Where Cost Lands">
+    <div class="slide">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · Ethics Panel</span></div>
+        <div>19 / Where The Cost Lands</div>
+      </div>
+
+      <div class="tag" style="margin-top: 40px;">Four Inputs · One System</div>
+      <h2 class="title" style="margin-top: 20px; max-width: 1600px;">Every prompt sits on a stack of physical inputs. Worth naming them out loud.</h2>
+
+      <div class="cols-4" style="margin-top: 60px; gap: 22px;">
+        <div class="tier-card cap-block" style="min-height: 360px;">
+          <span class="icon-letter">⚡</span>
+          <h5>Electricity.</h5>
+          <p>Training a frontier model and serving its inference both draw megawatts continuously. Datacenter demand is now a material driver of grid planning in several U.S. regions.</p>
+        </div>
+        <div class="tier-card cap-block" style="min-height: 360px;">
+          <span class="icon-letter">💧</span>
+          <h5>Water.</h5>
+          <p>Evaporative cooling consumes potable or industrial water — sited disproportionately in arid regions. The Southwest is a relevant case in this room.</p>
+        </div>
+        <div class="tier-card cap-block" style="min-height: 360px;">
+          <span class="icon-letter">⛏</span>
+          <h5>Embodied carbon.</h5>
+          <p>Accelerator manufacturing, server build, building shell, fiber, copper. The carbon cost is paid before the first prompt — and is rarely on the accounting.</p>
+        </div>
+        <div class="tier-card cap-block" style="min-height: 360px;">
+          <span class="icon-letter">🏗</span>
+          <h5>Siting &amp; land.</h5>
+          <p>Hyperscale datacenter buildout reshapes local economies, tax bases, transmission corridors, and noise envelopes. The externalities are not evenly distributed.</p>
+        </div>
+      </div>
+
+      <p class="small" style="margin-top: 40px; max-width: 1700px; font-size: 24px;">
+        Frame: AI's environmental cost is not one number. It is at least four numbers, on at least three timescales (training, inference, buildout).
+      </p>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>19 · COST</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       20 · MARGINAL COMPUTE COST
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="20 Marginal Cost" class="slide-paper">
+    <div class="slide slide-paper">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · Ethics Panel</span></div>
+        <div>20 / Marginal Cost</div>
+      </div>
+
+      <div class="tag" style="margin-top: 40px;">A Per-Call Heuristic</div>
+      <h2 class="title" style="margin-top: 20px; max-width: 1600px;">Two questions worth asking before every agentic loop.</h2>
+
+      <div class="footprint" style="margin-top: 60px;">
+        <div class="fp-card">
+          <div class="label">Q1 · Right-size the model</div>
+          <h4>Does this task actually need the frontier?</h4>
+          <div class="figrow"><div class="k">Tiny / local</div><div class="bar"><div class="fill" style="width: 12%;"></div></div></div>
+          <div class="figrow"><div class="k">Small hosted</div><div class="bar"><div class="fill" style="width: 28%;"></div></div></div>
+          <div class="figrow"><div class="k">Mid</div><div class="bar"><div class="fill" style="width: 52%;"></div></div></div>
+          <div class="figrow"><div class="k">Frontier</div><div class="bar"><div class="fill" style="width: 100%;"></div></div></div>
+          <p>Per-call energy and embodied compute scale with model size. Most tasks fit inside a smaller model — defaulting to the frontier is a habit, not a requirement. <em>(Figure is illustrative, not measured.)</em></p>
+        </div>
+        <div class="fp-card">
+          <div class="label">Q2 · Right-size the loop</div>
+          <h4>Does this agent need to retry forty times?</h4>
+          <div class="figrow"><div class="k">One-shot</div><div class="bar alt"><div class="fill" style="width: 10%;"></div></div></div>
+          <div class="figrow"><div class="k">+ retries</div><div class="bar alt"><div class="fill" style="width: 24%;"></div></div></div>
+          <div class="figrow"><div class="k">+ tool calls</div><div class="bar alt"><div class="fill" style="width: 55%;"></div></div></div>
+          <div class="figrow"><div class="k">Speculative agent</div><div class="bar alt"><div class="fill" style="width: 96%;"></div></div></div>
+          <p>Agentic loops fire speculative calls, retries, and tool calls behind one user action. Cumulative compute, not the visible turn count, is the cost. Cache. Cap retries. Watch the loop.</p>
+        </div>
+      </div>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>20 · MARGINAL COST</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       21 · ENVIRONMENTAL ETHICS BRIDGE
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="21 Environmental Bridge">
+    <div class="slide">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · Ethics Panel</span></div>
+        <div>21 / Bridge</div>
+      </div>
+
+      <div class="tag" style="margin-top: 40px;">Bridge · The Two Halves Are The Same Conversation</div>
+      <h2 class="title" style="margin-top: 20px; max-width: 1600px;">Environmental impact <em>is</em> an ethics question. Same publics. Same diffuse harms.</h2>
+
+      <div class="cols-2-uneven" style="margin-top: 70px; gap: 80px; flex: 0 1 auto;">
+        <div style="display: flex; flex-direction: column; justify-content: center;">
+          <p class="pullquote">
+            Collective, diffuse, opaque harms that older rights frameworks address only partially.
+          </p>
+          <div class="attrib">Nelson · on algorithmic harms — and equally on environmental ones</div>
+        </div>
+        <div style="display: flex; flex-direction: column; gap: 22px; justify-content: center;">
+          <div class="card">
+            <div class="kicker">Same structural pattern</div>
+            <p style="font-size: 26px;">
+              Datacenter siting, grid load, and water draw produce harms that are <strong style="color: var(--ink);">collective, diffuse, and opaque</strong> — the same shape as algorithmic harm.
+              Marshall's social-rights tier is the same conceptual address.
+            </p>
+          </div>
+          <div class="card" style="border-left: 6px solid var(--ua-red);">
+            <div class="kicker">Same convergence</div>
+            <p style="font-size: 26px;">
+              <em>Laudato Si'</em> (2015, on care for creation) and <em>Magnifica Humanitas</em> (2026, on AI) share a single underlying claim:
+              <strong style="color: var(--ink);">the environment and the economy and the technology are one moral question.</strong>
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>21 · BRIDGE</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       22 · PART 5 · DIVIDER · PANEL DISCUSSION
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="22 Part 5 Divider" class="slide-dark">
+    <div class="section-slide">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · Ethics Panel</span></div>
+        <div>Part 05 · Panel Discussion</div>
+      </div>
+      <div>
+        <div class="part-num">Part 05</div>
+        <h2 class="section-title">Over to<br>the panel<span style="color: var(--ua-red-bright);">.</span></h2>
+        <p class="section-sub">
+          Six prompts. The framing above is shared substrate — disagreement with it is fair game.
+        </p>
+      </div>
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>22 · PART 05</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       23 · DISCUSSION QUESTIONS
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="23 Discussion Questions" class="slide-paper">
+    <div class="slide slide-paper">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · Ethics Panel</span></div>
+        <div>23 / Questions</div>
+      </div>
+
+      <div class="tag" style="margin-top: 28px;">Six Prompts For The Panel</div>
+      <h2 class="title" style="margin-top: 12px; max-width: 1600px; font-size: 56px;">Pick the one you most want to argue with first.</h2>
+
+      <div style="display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 24px; margin-top: 40px;">
+        <div class="q-block">
+          <div class="qnum">Q1 · Legitimacy</div>
+          <h5>If corporate AI constitutions are structurally insufficient, what is the minimum public mechanism that <em>is</em> sufficient?</h5>
+          <p>Not principles. Mechanism.</p>
+        </div>
+        <div class="q-block">
+          <div class="qnum">Q2 · Civic grammar</div>
+          <h5>Is the convergence across partisan lines a sign of strength — or evidence the vocabulary has been drained of force?</h5>
+          <p>Nelson asks both. Pick one to defend.</p>
+        </div>
+        <div class="q-block">
+          <div class="qnum">Q3 · Magnifica Humanitas</div>
+          <h5>Does the theological vocabulary (infinite dignity, transhumanism, posthumanism) help or hinder public deliberation about AI?</h5>
+          <p>You can dislike the framing and still answer.</p>
+        </div>
+        <div class="q-block">
+          <div class="qnum">Q4 · Public health</div>
+          <h5>What algorithmic harm in public health practice today would <em>most</em> benefit from a Marshall-style social-rights response?</h5>
+          <p>Be specific. Name a system.</p>
+        </div>
+        <div class="q-block">
+          <div class="qnum">Q5 · Footprint</div>
+          <h5>Is "use a smaller model when you can" an adequate environmental ethic — or is it a personal-virtue dodge?</h5>
+          <p>Compare to "use less plastic."</p>
+        </div>
+        <div class="q-block">
+          <div class="qnum">Q6 · Trade-off</div>
+          <h5>When does a documented public-health benefit of an AI tool outweigh its documented environmental cost — and who gets to decide?</h5>
+          <p>The hardest question. Save it for last.</p>
+        </div>
+      </div>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>23 · QUESTIONS</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       24 · RESOURCES
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="24 Resources">
+    <div class="slide">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · Ethics Panel</span></div>
+        <div>24 / Resources</div>
+      </div>
+
+      <div class="tag" style="margin-top: 40px;">Bookmarks</div>
+      <h2 class="title" style="margin-top: 20px; max-width: 1600px;">Where to keep reading after the room empties out.</h2>
+
+      <div class="stack" style="margin-top: 60px;">
+        <div class="stack-row">
+          <div class="label">Course page</div>
+          <div class="val mono" style="color: var(--ua-red); font-size: 26px;">tyson-swetnam.github.io/intro-gpt/ethics/</div>
+        </div>
+        <div class="stack-row">
+          <div class="label">Nelson · 2026</div>
+          <div class="val" style="font-size: 26px;"><strong>A civic grammar for AI rights</strong>, Science · DOI 10.1126/science.aeh7153</div>
+        </div>
+        <div class="stack-row">
+          <div class="label">Nelson · 2026</div>
+          <div class="val" style="font-size: 26px;"><strong>Field Theory: AI as Social Science Question, Object &amp; Tool</strong> · Daedalus, Winter/Spring 2026</div>
+        </div>
+        <div class="stack-row">
+          <div class="label">Marshall · 1950</div>
+          <div class="val" style="font-size: 26px;">Citizenship and Social Class — the social-rights argument Nelson builds on</div>
+        </div>
+        <div class="stack-row">
+          <div class="label">OSTP · 2022</div>
+          <div class="val" style="font-size: 26px;">Blueprint for an AI Bill of Rights — bidenwhitehouse.archives.gov/ostp/ai-bill-of-rights/</div>
+        </div>
+        <div class="stack-row">
+          <div class="label">Leo XIV · 2026</div>
+          <div class="val" style="font-size: 26px;"><em>Magnifica Humanitas</em> · vatican.va/content/leo-xiv/…/magnifica-humanitas.html</div>
+        </div>
+        <div class="stack-row">
+          <div class="label">Bias · Legal · Transparency</div>
+          <div class="val mono" style="color: var(--ua-red); font-size: 24px;">/intro-gpt/bias/ · /intro-gpt/legal/ · /intro-gpt/transparency/</div>
+        </div>
+      </div>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>24 · RESOURCES</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       25 · CLOSING
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="25 Closing" class="slide-dark">
+    <div class="slide slide-dark">
+      <div class="title-slide">
+        <div class="grid-bg"></div>
+        <div class="deck-header">
+          <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · Ethics Panel</span></div>
+          <div>End · Thank You</div>
+        </div>
+
+        <div class="title-slide-content" style="margin-top: 0;">
+          <div class="tag" style="color: var(--cream-warm);">Three days. One conversation that doesn't end here.</div>
+          <h2 class="display" style="font-size: 168px;">
+            Keep<br>arguing<span style="color: var(--ua-red-bright);">.</span>
+          </h2>
+          <p class="body" style="max-width: 1300px; font-size: 34px;">
+            The civic grammar gets traction because publics use it. The footprint shrinks because
+            engineers and researchers refuse the default. Both are unfinished work — and both belong
+            to the room that just spent three days in it.
+          </p>
+        </div>
+
+        <div class="title-slide-content" style="gap: 12px;">
+          <div style="background: rgba(247,244,238,0.4); height: 1px; max-width: 600px;"></div>
+          <div style="display: flex; justify-content: space-between; align-items: flex-end;">
+            <div>
+              <div style="color: var(--cream); font-weight: 600; font-size: 32px;">Tyson Swetnam, PhD</div>
+              <div class="small mono" style="margin-top: 6px;">tswetnam@arizona.edu · @tswetnam</div>
+            </div>
+            <div class="mono small" style="text-align: right;">
+              BIO5 Institute · University of Arizona<br>
+              PH&amp;AI Summer School 2026
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+</deck-stage>
+
+</body>
+</html>

--- a/docs/tutorials/presentations/geospatial-ai-public-health.html
+++ b/docs/tutorials/presentations/geospatial-ai-public-health.html
@@ -1,0 +1,1526 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>Geospatial Analysis, AI-Powered — UA PH&amp;AI 2026</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Manrope:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+<script src="deck-stage.js"></script>
+<style>
+  :root {
+    /* University of Arizona palette */
+    --ua-blue:        #0C234B;
+    --ua-blue-deep:   #07173a;
+    --ua-blue-mid:    #1b3870;
+    --ua-red:         #AB0520;
+    --ua-red-bright:  #c8102e;
+    --cream:          #f7f4ee;
+    --cream-warm:     #efe9dc;
+    --paper:          #fbfaf6;
+    --ink:            #161616;
+    --ink-soft:       #2a2a2a;
+    --mute:           #6b6b6b;
+    --rule:           #d8d2c4;
+    --rule-strong:    #2a2a2a;
+    --code-bg:        #0f1623;
+    --code-fg:        #e6edf3;
+
+    /* Type scale — 1920x1080 */
+    --type-display:   140px;
+    --type-title:     72px;
+    --type-subtitle:  44px;
+    --type-body:      32px;
+    --type-small:     26px;
+    --type-tag:       24px;
+    --type-mono-sm:   24px;
+
+    /* Spacing */
+    --pad-x:          110px;
+    --pad-top:        96px;
+    --pad-bottom:     90px;
+    --gap-title:      48px;
+    --gap-item:       28px;
+  }
+
+  html, body { margin: 0; padding: 0; background: #000; }
+  body { font-family: 'Manrope', system-ui, sans-serif; color: var(--ink); }
+
+  deck-stage section {
+    box-sizing: border-box;
+    overflow: hidden;
+    background: var(--cream);
+    color: var(--ink);
+    font-family: 'Manrope', system-ui, sans-serif;
+    font-weight: 400;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  /* ── Shared atoms ──────────────────────────────────────────────── */
+  .slide {
+    padding: var(--pad-top) var(--pad-x) var(--pad-bottom);
+    height: 100%;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+  }
+  .slide-dark { background: var(--ua-blue); color: var(--cream); }
+  .slide-paper { background: var(--paper); }
+  .slide-red { background: var(--ua-red); color: var(--cream); }
+
+  .tag {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: var(--type-tag);
+    font-weight: 500;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--ua-red);
+  }
+  .slide-dark .tag { color: var(--cream-warm); opacity: 0.85; }
+  .slide-red .tag { color: var(--cream); opacity: 0.85; }
+
+  .title {
+    font-size: var(--type-title);
+    font-weight: 700;
+    line-height: 1.02;
+    letter-spacing: -0.02em;
+    margin: 0;
+    text-wrap: balance;
+  }
+  .display {
+    font-size: var(--type-display);
+    font-weight: 800;
+    line-height: 0.95;
+    letter-spacing: -0.035em;
+    margin: 0;
+    text-wrap: balance;
+  }
+  .subtitle {
+    font-size: var(--type-subtitle);
+    font-weight: 500;
+    line-height: 1.18;
+    color: var(--ink-soft);
+    margin: 0;
+    text-wrap: pretty;
+  }
+  .slide-dark .subtitle, .slide-red .subtitle { color: var(--cream-warm); }
+  .body {
+    font-size: var(--type-body);
+    font-weight: 400;
+    line-height: 1.42;
+    color: var(--ink-soft);
+    margin: 0;
+    text-wrap: pretty;
+  }
+  .slide-dark .body { color: var(--cream-warm); }
+  .small {
+    font-size: var(--type-small);
+    color: var(--mute);
+    line-height: 1.4;
+  }
+  .slide-dark .small { color: rgba(247,244,238,0.65); }
+  .mono { font-family: 'JetBrains Mono', monospace; }
+
+  /* Header bar with workshop/track identity */
+  .deck-header {
+    position: absolute;
+    top: 38px;
+    left: var(--pad-x);
+    right: var(--pad-x);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--mute);
+  }
+  .slide-dark .deck-header,
+  .slide-red .deck-header { color: rgba(247,244,238,0.55); }
+  .deck-header .lockup {
+    display: flex; align-items: center; gap: 14px;
+  }
+  .deck-header .ua-block {
+    display: inline-block;
+    width: 38px; height: 38px;
+    background: var(--ua-red);
+    color: var(--cream);
+    font-family: 'Manrope', sans-serif;
+    font-weight: 800;
+    font-size: 28px;
+    line-height: 38px;
+    text-align: center;
+    letter-spacing: -0.04em;
+  }
+  .slide-red .deck-header .ua-block { background: var(--cream); color: var(--ua-red); }
+
+  /* Footer crumb */
+  .deck-footer {
+    position: absolute;
+    bottom: 38px;
+    left: var(--pad-x);
+    right: var(--pad-x);
+    display: flex;
+    justify-content: space-between;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--mute);
+  }
+  .slide-dark .deck-footer,
+  .slide-red .deck-footer { color: rgba(247,244,238,0.5); }
+
+  /* Two-column generic */
+  .cols-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 80px; flex: 1; }
+  .cols-2-uneven { display: grid; grid-template-columns: 1.2fr 1fr; gap: 80px; flex: 1; }
+  .cols-3 { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 48px; flex: 1; }
+
+  /* Lists */
+  .checklist { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: var(--gap-item); }
+  .checklist li { display: flex; gap: 22px; font-size: var(--type-body); line-height: 1.35; color: var(--ink-soft); }
+  .checklist .num {
+    flex: 0 0 auto;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 26px;
+    font-weight: 500;
+    color: var(--ua-red);
+    padding-top: 10px;
+    letter-spacing: 0.06em;
+  }
+  .slide-dark .checklist li { color: var(--cream-warm); }
+  .slide-dark .checklist .num { color: var(--cream); opacity: 0.7; }
+
+  /* Cards */
+  .card {
+    background: var(--paper);
+    border: 1px solid var(--rule);
+    padding: 38px 40px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+  .slide-dark .card {
+    background: rgba(255,255,255,0.04);
+    border-color: rgba(247,244,238,0.18);
+    color: var(--cream);
+  }
+  .card h4 {
+    font-size: 36px;
+    font-weight: 700;
+    margin: 0;
+    letter-spacing: -0.01em;
+    line-height: 1.05;
+  }
+  .card p {
+    font-size: 26px;
+    line-height: 1.4;
+    color: var(--ink-soft);
+    margin: 0;
+  }
+  .slide-dark .card p { color: var(--cream-warm); }
+  .card .kicker {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--ua-red);
+  }
+
+  /* Code block */
+  pre.code {
+    background: var(--code-bg);
+    color: var(--code-fg);
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    line-height: 1.45;
+    padding: 36px 42px;
+    margin: 0;
+    border-radius: 4px;
+    overflow: hidden;
+    white-space: pre-wrap;
+  }
+  pre.code .c { color: #8b96a8; }
+  pre.code .k { color: #ffb86c; }
+  pre.code .s { color: #a6e22e; }
+  pre.code .v { color: #79c0ff; }
+
+  /* Decorative rule */
+  .rule { height: 1px; background: var(--rule); margin: 0; }
+  .rule-strong { height: 2px; background: var(--ink); margin: 0; }
+  .slide-dark .rule { background: rgba(247,244,238,0.18); }
+  .slide-dark .rule-strong { background: var(--cream); }
+
+  /* Big number block */
+  .bignum {
+    font-size: 240px;
+    font-weight: 800;
+    line-height: 0.85;
+    letter-spacing: -0.04em;
+    color: var(--ua-red);
+  }
+  .slide-dark .bignum { color: var(--cream); }
+
+  /* Image placeholder (striped, monospace label) */
+  .placeholder {
+    background:
+      repeating-linear-gradient(135deg,
+        rgba(12,35,75,0.06) 0,
+        rgba(12,35,75,0.06) 14px,
+        rgba(12,35,75,0.10) 14px,
+        rgba(12,35,75,0.10) 28px);
+    border: 1px solid var(--rule);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--ink-soft);
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    text-align: center;
+    padding: 24px;
+    box-sizing: border-box;
+  }
+  .slide-dark .placeholder {
+    background:
+      repeating-linear-gradient(135deg,
+        rgba(247,244,238,0.06) 0,
+        rgba(247,244,238,0.06) 14px,
+        rgba(247,244,238,0.10) 14px,
+        rgba(247,244,238,0.10) 28px);
+    border-color: rgba(247,244,238,0.2);
+    color: rgba(247,244,238,0.7);
+  }
+
+  /* Section divider slides */
+  .section-slide {
+    padding: var(--pad-top) var(--pad-x) var(--pad-bottom);
+    height: 100%;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    position: relative;
+  }
+  .section-slide .part-num {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 28px;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    opacity: 0.7;
+    margin-bottom: 36px;
+  }
+  .section-slide .section-title {
+    font-size: 160px;
+    font-weight: 800;
+    line-height: 0.92;
+    letter-spacing: -0.035em;
+    margin: 0;
+    text-wrap: balance;
+  }
+  .section-slide .section-sub {
+    font-size: 36px;
+    font-weight: 400;
+    line-height: 1.3;
+    max-width: 1100px;
+    margin-top: 36px;
+    opacity: 0.85;
+  }
+
+  /* Title slide */
+  .title-slide {
+    height: 100%;
+    box-sizing: border-box;
+    padding: var(--pad-top) var(--pad-x) var(--pad-bottom);
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    position: relative;
+  }
+  .title-slide .grid-bg {
+    position: absolute; inset: 0;
+    background-image:
+      linear-gradient(rgba(247,244,238,0.05) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(247,244,238,0.05) 1px, transparent 1px);
+    background-size: 80px 80px;
+    pointer-events: none;
+  }
+  .title-slide-content {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 60px;
+  }
+
+  /* Step header (lab steps) */
+  .step-label {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--ua-red);
+    margin-bottom: 18px;
+  }
+
+  /* Table */
+  table.surfaces {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 28px;
+  }
+  table.surfaces th, table.surfaces td {
+    text-align: left;
+    padding: 22px 24px;
+    border-bottom: 1px solid var(--rule);
+    vertical-align: top;
+  }
+  table.surfaces th {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    color: var(--mute);
+    font-weight: 500;
+    border-bottom: 2px solid var(--ink);
+  }
+  table.surfaces td.tool {
+    font-weight: 700;
+    color: var(--ink);
+    width: 28%;
+  }
+  table.surfaces td.kind {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    color: var(--ua-red);
+    width: 22%;
+  }
+  table.surfaces td.desc { color: var(--ink-soft); }
+
+  /* Stack ladder for tools list */
+  .stack { display: flex; flex-direction: column; gap: 0; }
+  .stack-row {
+    display: grid;
+    grid-template-columns: 280px 1fr;
+    gap: 40px;
+    padding: 28px 0;
+    border-bottom: 1px solid var(--rule);
+    align-items: baseline;
+  }
+  .stack-row:last-child { border-bottom: none; }
+  .stack-row .label {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    color: var(--ua-red);
+  }
+  .stack-row .val {
+    font-size: 30px;
+    color: var(--ink-soft);
+    line-height: 1.35;
+  }
+  .stack-row .val strong { color: var(--ink); font-weight: 700; }
+</style>
+</head>
+<body>
+
+<deck-stage width="1920" height="1080">
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       1 · TITLE SLIDE
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="01 Title" class="slide-dark">
+    <div class="title-slide">
+      <div class="grid-bg"></div>
+      <div class="deck-header">
+        <div class="lockup">
+          <span class="ua-block">A</span>
+          <span>University of Arizona · BIO5 Institute</span>
+        </div>
+        <div>PH&amp;AI Summer School · 2nd Edition</div>
+      </div>
+
+      <div class="title-slide-content" style="margin-top: 60px;">
+        <div class="tag" style="font-size: 26px;">Day 2 · AI Fluency Track · 10:30 AM</div>
+        <h1 class="display" style="font-size: 168px;">
+          Geospatial<br>Analysis,<br><span style="color: var(--ua-red-bright);">AI-Powered.</span>
+        </h1>
+      </div>
+
+      <div class="title-slide-content" style="gap: 12px;">
+        <div class="rule-strong" style="background: rgba(247,244,238,0.4); height: 1px; max-width: 600px;"></div>
+        <div style="display: flex; justify-content: space-between; align-items: flex-end;">
+          <div>
+            <div class="body" style="color: var(--cream); font-weight: 600; font-size: 36px;">Tyson Swetnam, PhD</div>
+            <div class="small" style="margin-top: 6px;">Associate Professor · BIO5 Institute</div>
+          </div>
+          <div class="mono small" style="text-align: right;">
+            Grand Challenges Research Building<br>
+            Tucson, AZ · June 9, 2026
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       2 · WHERE WE ARE IN THE PROGRAM
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="02 Where We Are">
+    <div class="slide">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>02 / Where We Are</div>
+      </div>
+
+      <div class="tag" style="margin-top: 40px;">Day 2 · Tuesday, June 9</div>
+      <h2 class="title" style="margin-top: 24px; max-width: 1500px;">Data &amp; Digital Health — and where geospatial fits in.</h2>
+
+      <div style="margin-top: 60px; flex: 1; display: flex; flex-direction: column; gap: 0;">
+        <div class="stack-row" style="grid-template-columns: 220px 320px 1fr; gap: 32px; padding: 22px 0;">
+          <div class="mono small" style="color: var(--mute); letter-spacing: 0.14em;">09:00</div>
+          <div class="body" style="font-weight: 600; color: var(--ink); font-size: 30px;">AI in Patient Care &amp; Digital Health Cohorts</div>
+          <div class="small" style="color: var(--mute);">All Tracks · Slepian</div>
+        </div>
+        <div class="stack-row" style="grid-template-columns: 220px 320px 1fr; gap: 32px; background: var(--ua-blue); margin: 0 -40px; padding: 24px 40px;">
+          <div class="mono small" style="color: var(--cream-warm); letter-spacing: 0.14em;">10:30 · YOU ARE HERE</div>
+          <div class="body" style="font-weight: 700; color: var(--cream); font-size: 32px;">Geospatial Analysis, AI-Powered</div>
+          <div class="small" style="color: rgba(247,244,238,0.7);">AI Fluency · Swetnam · 90 min lab</div>
+        </div>
+        <div class="stack-row" style="grid-template-columns: 220px 320px 1fr; gap: 32px; padding: 22px 0;">
+          <div class="mono small" style="color: var(--mute); letter-spacing: 0.14em;">13:00</div>
+          <div class="body" style="font-weight: 600; color: var(--ink); font-size: 30px;">AI Maker Space — Data Projects</div>
+          <div class="small" style="color: var(--mute);">All Tracks · Florez-Arango</div>
+        </div>
+        <div class="stack-row" style="grid-template-columns: 220px 320px 1fr; gap: 32px; padding: 22px 0;">
+          <div class="mono small" style="color: var(--mute); letter-spacing: 0.14em;">15:30</div>
+          <div class="body" style="font-weight: 600; color: var(--ink); font-size: 30px;">Fireside Chat — Gaps in AI &amp; Health Training</div>
+          <div class="small" style="color: var(--mute);">All Tracks · Leal Neto &amp; Weinstein</div>
+        </div>
+      </div>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>02 · WHERE WE ARE</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       3 · WHAT YOU'LL BUILD
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="03 What You'll Build">
+    <div class="slide slide-paper">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>03 / Outcome</div>
+      </div>
+
+      <div class="cols-2-uneven" style="margin-top: 60px;">
+        <div style="display: flex; flex-direction: column; justify-content: space-between;">
+          <div>
+            <div class="tag">In 90 Minutes</div>
+            <h2 class="title" style="margin-top: 22px;">A scrolling Leaflet story-map of the 1850 London cholera outbreak.</h2>
+            <p class="body" style="margin-top: 36px; max-width: 720px;">
+              Served locally at <span class="mono" style="color: var(--ua-red); font-size: 28px;">http://localhost:51234</span>.
+              By minute 60 you should see the Broad Street pump and the death-density choropleth on screen.
+            </p>
+          </div>
+          <ul class="checklist" style="margin-top: 50px;">
+            <li><span class="num">01</span><div><strong style="color: var(--ink);">Open data in,</strong> interactive map out — no GIS desktop required.</div></li>
+            <li><span class="num">02</span><div><strong style="color: var(--ink);">An agent did the typing.</strong> You did the directing.</div></li>
+            <li><span class="num">03</span><div><strong style="color: var(--ink);">A workflow</strong> you can re-aim at any public health dataset.</div></li>
+          </ul>
+        </div>
+        <div class="placeholder" style="min-height: 100%;">
+          [ screenshot ]<br>snow_storymap.html<br>broad-street pump + choropleth
+        </div>
+      </div>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>03 · OUTCOME</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       4 · SECTION DIVIDER · PART 1
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="04 Part 1 Divider" class="slide-dark">
+    <div class="section-slide">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>Part 01 · Foundations</div>
+      </div>
+      <div>
+        <div class="part-num">Part 01</div>
+        <h2 class="section-title">Foundations.</h2>
+        <p class="section-sub">
+          The vocabulary, the surfaces, and the loop — so we share a language
+          before we share a keyboard.
+        </p>
+      </div>
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>04 · PART 01</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       5 · THE 2026 AGENT LANDSCAPE
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="05 Agent Landscape">
+    <div class="slide">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>05 / Landscape</div>
+      </div>
+
+      <div class="tag" style="margin-top: 40px;">The 2026 Picture</div>
+      <h2 class="title" style="margin-top: 24px; max-width: 1500px;">The frontier moved from chat windows to agents with hands.</h2>
+
+      <div class="cols-3" style="margin-top: 90px;">
+        <div class="card">
+          <div class="kicker">2022 — 2024</div>
+          <h4>Chat.</h4>
+          <p>You type, it replies. The model sees only your message. Useful, but you copy-paste everything.</p>
+        </div>
+        <div class="card" style="background: var(--cream-warm);">
+          <div class="kicker">2024 — 2025</div>
+          <h4>Tools.</h4>
+          <p>The model gains a code interpreter, file uploads, web search. Still a single turn, single surface.</p>
+        </div>
+        <div class="card" style="background: var(--ua-blue); border-color: var(--ua-blue); color: var(--cream);">
+          <div class="kicker" style="color: var(--cream-warm);">2025 — 2026</div>
+          <h4 style="color: var(--cream);">Agents.</h4>
+          <p style="color: var(--cream-warm);">The model reads your filesystem, runs commands, edits code, opens a browser — and reports back.</p>
+        </div>
+      </div>
+
+      <p class="small" style="margin-top: 60px; max-width: 1200px;">
+        Today's lab assumes the third column. If you are still living in the first, the gap is mostly muscle memory — not capability.
+      </p>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>05 · LANDSCAPE</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       6 · VIBE CODING
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="06 Vibe Coding">
+    <div class="slide">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>06 / Vocabulary</div>
+      </div>
+
+      <div class="cols-2" style="margin-top: 40px;">
+        <div style="display: flex; flex-direction: column; justify-content: center; gap: 30px;">
+          <div class="tag">Vibe Coding</div>
+          <h2 class="display" style="font-size: 120px;">Vibe<br>Coding.</h2>
+          <p class="body" style="max-width: 640px; font-size: 30px;">
+            You describe the <em>feel</em> of what you want — the shape, the behavior,
+            the audience — and let the agent produce, run, and refine the code.
+          </p>
+          <p class="small" style="max-width: 640px;">
+            Coined by Andrej Karpathy, 2025. Useful for prototypes, demos, internal tools,
+            and any disposable code where shipping fast beats writing it yourself.
+          </p>
+        </div>
+        <div style="display: flex; flex-direction: column; justify-content: center; gap: 28px;">
+          <div class="card">
+            <div class="kicker">What it is good for</div>
+            <p style="font-size: 28px;">First drafts. UI iteration. Throwaway scripts. "Can we visualize this?" moments. Today's storymap.</p>
+          </div>
+          <div class="card" style="border-color: var(--ua-red); border-width: 1px;">
+            <div class="kicker">What it is NOT</div>
+            <p style="font-size: 28px;">A substitute for code review on anything that handles PHI, runs in production, or makes clinical decisions.</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>06 · VIBE CODING</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       7 · AGENTIC ENGINEERING
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="07 Agentic Engineering">
+    <div class="slide slide-paper">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>07 / Vocabulary</div>
+      </div>
+
+      <div class="cols-2" style="margin-top: 40px;">
+        <div style="display: flex; flex-direction: column; justify-content: center; gap: 30px;">
+          <div class="tag">Agentic Engineering</div>
+          <h2 class="display" style="font-size: 110px;">Agentic<br>Engineering.</h2>
+          <p class="body" style="max-width: 640px; font-size: 30px;">
+            The discipline of building software <em>through</em> an agent: setting up
+            context files, naming reusable skills, version-controlling prompts,
+            and treating the model as a teammate with a job description.
+          </p>
+        </div>
+        <div style="display: flex; flex-direction: column; justify-content: center; gap: 22px;">
+          <div class="stack">
+            <div class="stack-row">
+              <div class="label">Context</div>
+              <div class="val"><strong>AGENTS.md / CLAUDE.md</strong> — stack, conventions, guardrails.</div>
+            </div>
+            <div class="stack-row">
+              <div class="label">Skills</div>
+              <div class="val"><strong>Skills.md</strong> — named, reusable playbooks the agent can invoke.</div>
+            </div>
+            <div class="stack-row">
+              <div class="label">Memory</div>
+              <div class="val"><strong>Memory.md</strong> — persistent project facts that survive sessions.</div>
+            </div>
+            <div class="stack-row">
+              <div class="label">Logs</div>
+              <div class="val"><strong>prompts/NNN_*.md</strong> — every prompt versioned alongside the code.</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>07 · AGENTIC ENGINEERING</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       8 · THREE SURFACES
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="08 Three Surfaces">
+    <div class="slide">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>08 / Tooling</div>
+      </div>
+
+      <div class="tag" style="margin-top: 40px;">Pick One From Each Row</div>
+      <h2 class="title" style="margin-top: 24px; max-width: 1500px;">Three surfaces, the same agent underneath.</h2>
+
+      <table class="surfaces" style="margin-top: 60px;">
+        <thead>
+          <tr>
+            <th style="width: 28%;">Surface</th>
+            <th style="width: 22%;">Best For</th>
+            <th>Examples</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td class="tool">Desktop LLM apps</td>
+            <td class="kind">Chat + artifacts</td>
+            <td class="desc">Claude Desktop · ChatGPT (Codex) · Perplexity Comet</td>
+          </tr>
+          <tr>
+            <td class="tool">CLI agents</td>
+            <td class="kind">Filesystem access</td>
+            <td class="desc">Claude Code · Codex CLI · Gemini CLI</td>
+          </tr>
+          <tr>
+            <td class="tool">AI-native IDEs</td>
+            <td class="kind">In-editor flow</td>
+            <td class="desc">VS Code (+ Copilot) · Cursor · Antigravity (Google)</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <p class="small" style="margin-top: 50px; max-width: 1300px;">
+        The prompts in today's lab are platform-neutral. Use whichever surface
+        you already know — the workflow transfers.
+      </p>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>08 · SURFACES</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       9 · SECTION DIVIDER · PART 2
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="09 Part 2 Divider" class="slide-dark">
+    <div class="section-slide">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>Part 02 · AI for Geospatial Work</div>
+      </div>
+      <div>
+        <div class="part-num">Part 02</div>
+        <h2 class="section-title">AI, meet<br>the GIS stack.</h2>
+        <p class="section-sub">
+          Where agents already plug in — and where you, the analyst,
+          still have to do the thinking.
+        </p>
+      </div>
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>09 · PART 02</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       10 · WHERE AI FITS THE GEOSPATIAL STACK
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="10 Where AI Fits">
+    <div class="slide">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>10 / Map of the Map-Maker's Toolkit</div>
+      </div>
+
+      <div class="tag" style="margin-top: 40px;">A Layered View</div>
+      <h2 class="title" style="margin-top: 24px; max-width: 1500px;">Four layers an agent can write code against today.</h2>
+
+      <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 36px; margin-top: 70px; flex: 1;">
+        <div class="card">
+          <div class="kicker">Layer 01 · Scripting</div>
+          <h4>Python &amp; OSGeo CLI.</h4>
+          <p>geopandas, rasterio, shapely · gdal, ogr2ogr, pyproj. The agent writes, runs, and debugs in your shell.</p>
+        </div>
+        <div class="card">
+          <div class="kicker">Layer 02 · Desktop GIS</div>
+          <h4>ArcGIS &amp; QGIS.</h4>
+          <p>Reachable through Model Context Protocol servers (QGISMCP) — the agent drives the GUI for layer styling, processing, atlases.</p>
+        </div>
+        <div class="card" style="background: var(--ua-blue); color: var(--cream); border-color: var(--ua-blue);">
+          <div class="kicker" style="color: var(--cream-warm);">Layer 03 · Cloud</div>
+          <h4 style="color: var(--cream);">Google Earth Engine.</h4>
+          <p style="color: var(--cream-warm);">Petabyte-scale satellite catalog, JS &amp; Python APIs. Agents are excellent at boilerplate ingestion and reducer chains.</p>
+        </div>
+        <div class="card" style="background: var(--ua-red); color: var(--cream); border-color: var(--ua-red);">
+          <div class="kicker" style="color: var(--cream-warm);">Layer 04 · Web</div>
+          <h4 style="color: var(--cream);">Leaflet &amp; MapLibre GL.</h4>
+          <p style="color: var(--cream-warm);">Plain HTML / CSS / JS. The fastest path from "I have a GeoJSON" to "share this link." Today's deliverable.</p>
+        </div>
+      </div>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>10 · STACK</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       11 · OSGeo SCRIPTING
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="11 OSGeo Scripting" class="slide-paper">
+    <div class="slide slide-paper">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>11 / Layer 01 · Scripting</div>
+      </div>
+
+      <div class="cols-2-uneven" style="margin-top: 40px;">
+        <div style="display: flex; flex-direction: column; justify-content: center;">
+          <div class="tag">Layer 01 · Scripting</div>
+          <h2 class="title" style="margin-top: 24px;">Python and OSGeo, written by the agent.</h2>
+          <p class="body" style="margin-top: 32px;">
+            The CLI tools the geo community has used for thirty years
+            are now the agent's preferred plumbing. They are well-documented,
+            deterministic, and easy to verify.
+          </p>
+          <p class="small" style="margin-top: 30px;">
+            Your job shifts from <span class="mono" style="color: var(--ua-red); font-size: 24px;">man gdalwarp</span>
+            to specifying inputs, outputs, and expected CRS.
+          </p>
+        </div>
+        <pre class="code"><span class="c"># Prompt: reproject every shapefile in data/raw/</span>
+<span class="c"># to EPSG:4326 and save as GeoJSON in data/clean/.</span>
+
+<span class="k">for</span> f <span class="k">in</span> data/raw/*.shp; <span class="k">do</span>
+  name=$(<span class="v">basename</span> <span class="s">"$f"</span> .shp)
+  ogr2ogr \
+    -f <span class="s">"GeoJSON"</span> \
+    -t_srs EPSG:4326 \
+    data/clean/<span class="s">"$name"</span>.geojson \
+    <span class="s">"$f"</span>
+<span class="k">done</span>
+
+<span class="c"># Verify with one line of geopandas:</span>
+<span class="v">python</span> -c \
+  <span class="s">"import geopandas as gpd;
+print(gpd.read_file('data/clean/cases.geojson').crs)"</span></pre>
+      </div>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>11 · SCRIPTING</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       12 · DESKTOP GIS via MCP
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="12 Desktop GIS">
+    <div class="slide">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>12 / Layer 02 · Desktop GIS</div>
+      </div>
+
+      <div class="tag" style="margin-top: 40px;">Layer 02 · Desktop GIS</div>
+      <h2 class="title" style="margin-top: 24px; max-width: 1600px;">Your QGIS canvas, on the other end of an MCP server.</h2>
+
+      <div class="cols-2" style="margin-top: 80px;">
+        <div style="display: flex; flex-direction: column; gap: 28px;">
+          <p class="body">
+            <strong style="color: var(--ink);">Model Context Protocol</strong>
+            is the standard plug for "tool" servers — and the geo community
+            already shipped one for QGIS.
+          </p>
+          <div class="stack">
+            <div class="stack-row">
+              <div class="label">QGISMCP</div>
+              <div class="val">Add layers, style, run Processing toolbox, export atlas pages.</div>
+            </div>
+            <div class="stack-row">
+              <div class="label">ArcGIS Pro</div>
+              <div class="val">AI assistants via the ArcGIS Python Notebook + arcpy.</div>
+            </div>
+            <div class="stack-row">
+              <div class="label">Esri Maps SDK</div>
+              <div class="val">Agent-friendly REST endpoints for hosted feature services.</div>
+            </div>
+          </div>
+        </div>
+        <div class="placeholder" style="min-height: 480px;">
+          [ screenshot ]<br>QGIS canvas + Claude side-panel<br>driving layer styling
+        </div>
+      </div>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>12 · DESKTOP GIS</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       13 · GOOGLE EARTH ENGINE
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="13 Earth Engine" class="slide-dark">
+    <div class="slide slide-dark">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>13 / Layer 03 · Cloud</div>
+      </div>
+
+      <div class="cols-2-uneven" style="margin-top: 40px;">
+        <div style="display: flex; flex-direction: column; justify-content: center;">
+          <div class="tag">Layer 03 · Cloud</div>
+          <h2 class="title" style="margin-top: 24px; color: var(--cream);">Earth Engine, scripted on tap.</h2>
+          <p class="body" style="margin-top: 32px;">
+            The petabyte-scale public satellite catalog. The agent is excellent at
+            generating boilerplate: collection filters, cloud masks, reducers, exports.
+          </p>
+          <p class="small" style="margin-top: 30px;">
+            What you still own: choosing the right collection, defining the temporal
+            window, sanity-checking the output against ground truth.
+          </p>
+        </div>
+        <pre class="code"><span class="c"># Prompt: monthly NDVI for Pima County,</span>
+<span class="c"># 2024, Sentinel-2 Surface Reflectance.</span>
+
+<span class="k">import</span> ee
+ee.Initialize()
+
+aoi = ee.FeatureCollection(
+    <span class="s">"TIGER/2018/Counties"</span>) \
+  .filter(ee.Filter.eq(
+      <span class="s">"NAME"</span>, <span class="s">"Pima"</span>))
+
+s2 = (ee.ImageCollection(<span class="s">"COPERNICUS/S2_SR"</span>)
+        .filterBounds(aoi)
+        .filterDate(<span class="s">"2024-01-01"</span>,
+                    <span class="s">"2025-01-01"</span>)
+        .map(ndvi))</pre>
+      </div>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>13 · EARTH ENGINE</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       14 · WEB MAPPING
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="14 Web Mapping">
+    <div class="slide">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>14 / Layer 04 · Web</div>
+      </div>
+
+      <div class="tag" style="margin-top: 40px;">Layer 04 · Web Mapping</div>
+      <h2 class="title" style="margin-top: 24px; max-width: 1500px;">From <span class="mono" style="font-size: 56px; color: var(--ua-red);">.geojson</span> to a shareable link, in one prompt.</h2>
+
+      <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 48px; margin-top: 70px; flex: 1;">
+        <div class="card">
+          <div class="kicker">Leaflet</div>
+          <h4>The pragmatic default.</h4>
+          <p>Tile-based, tiny API, every public health JS map you've seen in the wild. Today's lab uses it.</p>
+          <p class="mono" style="font-size: 24px; color: var(--ua-red); margin-top: 8px;">~42 KB · works everywhere</p>
+        </div>
+        <div class="card">
+          <div class="kicker">MapLibre GL</div>
+          <h4>The vector successor.</h4>
+          <p>Open fork of Mapbox GL. WebGL-rendered vector tiles, smooth interaction, full styling spec. Reach for it when Leaflet hits a wall.</p>
+          <p class="mono" style="font-size: 24px; color: var(--ua-red); margin-top: 8px;">vector tiles · 3D terrain · MIT</p>
+        </div>
+      </div>
+
+      <p class="small" style="margin-top: 50px; max-width: 1400px;">
+        Both are plain HTML / CSS / JS. No bundler, no framework — which means the agent's output is
+        a single file you can read, edit, and host on any static server.
+      </p>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>14 · WEB MAPPING</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       15 · SECTION DIVIDER · PART 3
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="15 Part 3 Divider" class="slide-red">
+    <div class="section-slide">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>Part 03 · The Lab</div>
+      </div>
+      <div>
+        <div class="part-num">Part 03</div>
+        <h2 class="section-title">The lab.</h2>
+        <p class="section-sub">
+          Four steps. Ninety minutes. One scrolling map of a 175-year-old outbreak —
+          built end-to-end by directing an agent.
+        </p>
+      </div>
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>15 · PART 03</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       16 · THE STORY — 1850 CHOLERA
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="16 The Story">
+    <div class="slide slide-paper">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>16 / Why This Dataset</div>
+      </div>
+
+      <div class="cols-2-uneven" style="margin-top: 40px;">
+        <div style="display: flex; flex-direction: column; justify-content: center;">
+          <div class="tag">Why This Dataset</div>
+          <h2 class="title" style="margin-top: 24px;">John Snow, Broad Street, 1854.</h2>
+          <p class="body" style="margin-top: 32px;">
+            The founding dataset of modern epidemiology. Geocoded cholera deaths,
+            pump locations, and the spatial argument that broke the miasma theory.
+          </p>
+          <p class="body" style="margin-top: 24px;">
+            Small enough to load in a browser. Famous enough that every public
+            health professional in this room has seen the map — but probably
+            never built one themselves.
+          </p>
+          <p class="mono small" style="margin-top: 36px; color: var(--ua-red);">
+            geodacenter.github.io/data-and-lab/data/snow.zip
+          </p>
+        </div>
+        <div style="display: flex; flex-direction: column; gap: 20px;">
+          <div class="placeholder" style="height: 580px;">
+            [ image ]<br>John Snow's original<br>1854 cholera map
+          </div>
+          <p class="small" style="text-align: right;">Public domain · Wellcome Collection</p>
+        </div>
+      </div>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>16 · THE STORY</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       17 · WORKFLOW AT A GLANCE
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="17 Workflow">
+    <div class="slide">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>17 / Workflow</div>
+      </div>
+
+      <div class="tag" style="margin-top: 40px;">The Loop</div>
+      <h2 class="title" style="margin-top: 24px; max-width: 1500px;">Four steps. Each one a single, copy-able prompt.</h2>
+
+      <div style="display: grid; grid-template-columns: repeat(4, 1fr); gap: 28px; margin-top: 90px;">
+        <div class="card" style="padding: 32px;">
+          <div class="kicker">Step 0</div>
+          <h4 style="font-size: 32px;">Context.</h4>
+          <p style="font-size: 24px;">Drop in the three <span class="mono" style="font-size: 24px;">.md</span> files that tell the agent how this workspace operates.</p>
+        </div>
+        <div class="card" style="padding: 32px;">
+          <div class="kicker">Step 1</div>
+          <h4 style="font-size: 32px;">Scaffold.</h4>
+          <p style="font-size: 24px;">Folder tree, dataset download, unzip, sort GeoJSONs into <span class="mono" style="font-size: 24px;">map/</span>.</p>
+        </div>
+        <div class="card" style="padding: 32px;">
+          <div class="kicker">Step 2</div>
+          <h4 style="font-size: 32px;">Build.</h4>
+          <p style="font-size: 24px;">A scrolling Leaflet storymap, choropleth on <span class="mono" style="font-size: 24px;">deaths</span>, served on a local port.</p>
+        </div>
+        <div class="card" style="padding: 32px;">
+          <div class="kicker">Step 3 — 4</div>
+          <h4 style="font-size: 32px;">Iterate.</h4>
+          <p style="font-size: 24px;">Critique. Approve. Then a one-shot reveal: the same workflow, compressed to one prompt.</p>
+        </div>
+      </div>
+
+      <p class="small" style="margin-top: 70px; max-width: 1400px;">
+        We will walk steps 0 — 3 together. Step 4 is yours to try in a fresh chat.
+      </p>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>17 · WORKFLOW</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       18 · STEP 0
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="18 Step 0 Context">
+    <div class="slide slide-paper">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>18 / Step 0</div>
+      </div>
+
+      <div class="step-label" style="margin-top: 40px;">Step 00 — Set up context</div>
+      <h2 class="title" style="margin-top: 8px; max-width: 1600px;">Three markdown files. Same content. Whichever filename your agent expects.</h2>
+
+      <div class="cols-3" style="margin-top: 70px;">
+        <div class="card">
+          <div class="kicker">CLAUDE.md / AGENTS.md</div>
+          <h4 style="font-size: 30px;">Workspace rules.</h4>
+          <p style="font-size: 24px;">Stack (Python 3.10, Leaflet, no bundlers). Conventions (<span class="mono" style="font-size: 24px;">code/</span>, <span class="mono" style="font-size: 24px;">data/</span>, <span class="mono" style="font-size: 24px;">map/</span>). Guardrails (confirm destructive actions, never fabricate sample data).</p>
+        </div>
+        <div class="card">
+          <div class="kicker">Skills.md</div>
+          <h4 style="font-size: 30px;">Reusable playbooks.</h4>
+          <p style="font-size: 24px;"><span class="mono" style="font-size: 24px;">/scaffold</span>, <span class="mono" style="font-size: 24px;">/fetch-snow</span>, <span class="mono" style="font-size: 24px;">/storymap</span>, <span class="mono" style="font-size: 24px;">/critique</span> — named macros the agent can invoke.</p>
+        </div>
+        <div class="card">
+          <div class="kicker">Memory.md</div>
+          <h4 style="font-size: 30px;">Project facts.</h4>
+          <p style="font-size: 24px;">Field names (<span class="mono" style="font-size: 24px;">deaths</span>, <span class="mono" style="font-size: 24px;">deathdens</span>). Labels on polygons, not points. PI's stylistic preferences.</p>
+        </div>
+      </div>
+
+      <p class="small" style="margin-top: 70px; max-width: 1400px;">
+        This is the moment you stop treating the agent as a chatbot and start treating it as a teammate
+        with a contract.
+      </p>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>18 · STEP 00</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       19 · STEP 1 — SCAFFOLD
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="19 Step 1 Scaffold">
+    <div class="slide">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>19 / Step 1</div>
+      </div>
+
+      <div class="step-label" style="margin-top: 40px;">Step 01 — Scaffold &amp; fetch</div>
+      <h2 class="title" style="margin-top: 8px; max-width: 1600px;">Folder tree, dataset, sort. One prompt.</h2>
+
+      <div class="cols-2-uneven" style="margin-top: 50px;">
+        <pre class="code" style="font-size: 24px;">TASK
+1. Create folders:
+   data/, map/, code/, prompts/
+2. Download
+   geodacenter.github.io/data-and-lab
+     /data/snow.zip
+   into data/
+3. Unzip in place, delete the .zip
+4. Move every *.geojson from the
+   unzipped folder into map/.
+   Ignore __MACOSX, non-geojson.
+5. Save script as code/setup.py.
+   Confirm each step.</pre>
+        <div style="display: flex; flex-direction: column; gap: 24px; justify-content: center;">
+          <div class="card">
+            <div class="kicker">What to watch</div>
+            <p style="font-size: 24px;">The agent should <strong>announce each step</strong> and stop on the first failure. If it silently "succeeds" with no files in <span class="mono" style="font-size: 24px;">map/</span>, your Filesystem MCP isn't running.</p>
+          </div>
+          <div class="card" style="border-color: var(--ua-red);">
+            <div class="kicker">If the download fails</div>
+            <p style="font-size: 24px;">Grab the zip via your browser, drop it into <span class="mono" style="font-size: 24px;">data/</span>, and re-run from step 3.</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>19 · STEP 01</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       20 · STEP 2 — BUILD
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="20 Step 2 Build" class="slide-paper">
+    <div class="slide slide-paper">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>20 / Step 2</div>
+      </div>
+
+      <div class="step-label" style="margin-top: 40px;">Step 02 — Build the storymap</div>
+      <h2 class="title" style="margin-top: 8px; max-width: 1600px;">The centerpiece prompt. Layout, data styling, serve.</h2>
+
+      <div class="cols-2-uneven" style="margin-top: 50px;">
+        <pre class="code" style="font-size: 24px;">TASK
+Create map/snow_storymap.html using Leaflet
+(HTML/CSS/JS).
+
+Layout:
+  - Scrolly story-map
+  - Layers appear on scroll, fade past
+  - Short caption per layer
+
+Data styling:
+  - Choropleth on 'deaths', 'deathdens'
+  - Labels on polygons only (NOT points)
+
+Serve:
+  - python -m http.server 51234</pre>
+        <div style="display: flex; flex-direction: column; gap: 24px; justify-content: center;">
+          <div class="placeholder" style="height: 280px;">
+            [ screenshot ]<br>Expected output<br>scrolly map at :51234
+          </div>
+          <div class="card">
+            <div class="kicker">If a field is missing</div>
+            <p style="font-size: 24px;">If <span class="mono" style="font-size: 24px;">deathdens</span> isn't in the GeoJSON, ask the agent to compute it from <span class="mono" style="font-size: 24px;">deaths</span> divided by polygon area.</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>20 · STEP 02</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       21 · STEP 3 — ITERATE
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="21 Step 3 Iterate">
+    <div class="slide">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>21 / Step 3</div>
+      </div>
+
+      <div class="step-label" style="margin-top: 40px;">Step 03 — Iterate aesthetics</div>
+      <h2 class="title" style="margin-top: 8px; max-width: 1600px;">Critique. Approve. Apply. Time-box: 10 minutes.</h2>
+
+      <div class="cols-2" style="margin-top: 70px;">
+        <pre class="code" style="font-size: 24px;">TASK
+Open map/snow_storymap.html.
+Critique colors, fonts, and scroll feel.
+Propose up to 3 improvements.
+Wait for my approval, then apply
+them in place.</pre>
+        <div style="display: flex; flex-direction: column; gap: 24px; justify-content: center;">
+          <div class="stack">
+            <div class="stack-row">
+              <div class="label">Wait</div>
+              <div class="val">The agent should <strong>pause</strong> after proposing. If it edits immediately, your guardrails aren't being read.</div>
+            </div>
+            <div class="stack-row">
+              <div class="label">Approve</div>
+              <div class="val">Pick the changes you want. Reject the rest. Be specific.</div>
+            </div>
+            <div class="stack-row">
+              <div class="label">Apply</div>
+              <div class="val">"In place" means the same file path. No new variant files unless you ask.</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <p class="small" style="margin-top: 60px; max-width: 1400px;">
+        This is the most cuttable step if we're running short. The point is just to feel the iteration loop once.
+      </p>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>21 · STEP 03</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       22 · STEP 4 — ONE-SHOT REVEAL
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="22 Step 4 One Shot" class="slide-dark">
+    <div class="slide slide-dark">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>22 / Step 4</div>
+      </div>
+
+      <div class="step-label" style="margin-top: 40px; color: var(--cream-warm);">Step 04 — One-shot reveal</div>
+      <h2 class="title" style="margin-top: 8px; max-width: 1600px; color: var(--cream);">Now the same workflow, in a single prompt, in a fresh chat.</h2>
+
+      <div class="cols-2-uneven" style="margin-top: 60px;">
+        <div style="display: flex; flex-direction: column; justify-content: center; gap: 28px;">
+          <p class="body" style="max-width: 640px;">
+            We just walked four steps. The pedagogical point of step 4 is to
+            paste it all as one prompt and watch the agent execute end-to-end.
+          </p>
+          <p class="body" style="max-width: 640px;">
+            <strong style="color: var(--cream);">Yes, the prompt has typos.</strong> The numbering jumps. "Chloropleth" is misspelled.
+            Both are preserved on purpose — modern agents handle messy real-world prompts surprisingly well.
+          </p>
+          <p class="small">
+            Compare this output to the artifact you built across Steps 1–3.
+            Where did the agent do better with all-at-once context? Where did it cut corners?
+          </p>
+        </div>
+        <div class="card" style="background: rgba(255,255,255,0.04); border-color: rgba(247,244,238,0.18);">
+          <div class="kicker" style="color: var(--cream-warm);">The compressed prompt</div>
+          <p style="color: var(--cream); font-size: 24px; font-family: 'JetBrains Mono', monospace; line-height: 1.5;">
+            "Build a scrolling story telling map…
+            using Leaflet, HTML, CSS, and
+            JavaScript…
+            <br><br>
+            • layers appear on scroll<br>
+            • chloropleth on 'deaths' and<br>
+            &nbsp;&nbsp;'deathdens'<br>
+            • death count labels on polygons,<br>
+            &nbsp;&nbsp;not points"
+          </p>
+        </div>
+      </div>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>22 · STEP 04</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       23 · WHAT TO WATCH FOR
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="23 Watch For">
+    <div class="slide">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>23 / Guardrails</div>
+      </div>
+
+      <div class="tag" style="margin-top: 40px;">In Public Health Work, Especially</div>
+      <h2 class="title" style="margin-top: 24px; max-width: 1500px;">Three failure modes worth memorizing.</h2>
+
+      <div class="cols-3" style="margin-top: 90px;">
+        <div class="card">
+          <div class="kicker">01 · Fabrication</div>
+          <h4>Made-up data.</h4>
+          <p>Agents will invent plausible-looking sample data when a real fetch fails. Your guardrail: <em>never fabricate — surface failures and stop.</em></p>
+        </div>
+        <div class="card">
+          <div class="kicker">02 · Silent success</div>
+          <h4>"It worked" — but didn't.</h4>
+          <p>The script ran. No files appeared. Check the Filesystem MCP is actually connected, and ask the agent to <span class="mono" style="font-size: 24px;">ls map/</span> after every step.</p>
+        </div>
+        <div class="card">
+          <div class="kicker">03 · PHI in prompts</div>
+          <h4>What goes in the chat.</h4>
+          <p>Treat the prompt window like a public Slack channel. Strip identifiers before pasting. Use synthetic or geocoded-out datasets for development.</p>
+        </div>
+      </div>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>23 · GUARDRAILS</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       24 · OPTIONAL HOMEWORK
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="24 Homework" class="slide-paper">
+    <div class="slide slide-paper">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>24 / Optional Homework</div>
+      </div>
+
+      <div class="tag" style="margin-top: 40px;">Take It Further</div>
+      <h2 class="title" style="margin-top: 24px; max-width: 1500px;">Four directions, pick whichever interests you.</h2>
+
+      <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 36px; margin-top: 70px; flex: 1;">
+        <div class="card">
+          <div class="kicker">Sharpen your prompts</div>
+          <h4>Writing Prompts · Vibe Coding.</h4>
+          <p>Two deeper reads on the iterate-with-an-agent loop you just used in Step 3.</p>
+        </div>
+        <div class="card">
+          <div class="kicker">Bring documents in</div>
+          <h4>Text Mining · RAG.</h4>
+          <p>Replace the cut PDF-summary step. Extend the storymap with retrieval over the cholera primary sources.</p>
+        </div>
+        <div class="card">
+          <div class="kicker">Automate the workflow</div>
+          <h4>Claude Code Workflow · Agentic AI.</h4>
+          <p>Prompt logging, session automation, the agent loop framed end-to-end.</p>
+        </div>
+        <div class="card">
+          <div class="kicker">Ship &amp; extend</div>
+          <h4>QGISMCP · GitHub Pages.</h4>
+          <p>Rebuild the layers in QGIS via MCP. Deploy the map as a public static site.</p>
+        </div>
+      </div>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>24 · HOMEWORK</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       25 · RESOURCES & NEXT STEPS
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="25 Resources">
+    <div class="slide">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>25 / Resources</div>
+      </div>
+
+      <div class="tag" style="margin-top: 40px;">Bookmarks</div>
+      <h2 class="title" style="margin-top: 24px; max-width: 1500px;">Everything from today, in one place.</h2>
+
+      <div class="stack" style="margin-top: 80px;">
+        <div class="stack-row">
+          <div class="label">This Lab</div>
+          <div class="val mono" style="color: var(--ua-red); font-size: 26px;">tyson-swetnam.github.io/intro-gpt/tutorials/publichealth/gis/</div>
+        </div>
+        <div class="stack-row">
+          <div class="label">Full Workshop</div>
+          <div class="val mono" style="color: var(--ua-red); font-size: 26px;">tyson-swetnam.github.io/intro-gpt/</div>
+        </div>
+        <div class="stack-row">
+          <div class="label">Dataset</div>
+          <div class="val mono" style="color: var(--ua-red); font-size: 26px;">geodacenter.github.io/data-and-lab/data/snow.zip</div>
+        </div>
+        <div class="stack-row">
+          <div class="label">QGIS MCP</div>
+          <div class="val mono" style="color: var(--ua-red); font-size: 26px;">github.com/jjsantos01/qgis_mcp</div>
+        </div>
+        <div class="stack-row">
+          <div class="label">PH&amp;AI 2026</div>
+          <div class="val mono" style="color: var(--ua-red); font-size: 26px;">ph-ai.me</div>
+        </div>
+      </div>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>25 · RESOURCES</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       26 · THANK YOU / Q&A
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="26 Thank You" class="slide-dark">
+    <div class="slide slide-dark">
+      <div class="title-slide">
+        <div class="grid-bg"></div>
+        <div class="deck-header">
+          <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+          <div>End · Q&amp;A</div>
+        </div>
+
+        <div class="title-slide-content" style="margin-top: 0;">
+          <div class="tag" style="color: var(--cream-warm);">Now, the Maker Space</div>
+          <h2 class="display" style="font-size: 200px;">
+            Questions<span style="color: var(--ua-red-bright);">?</span>
+          </h2>
+          <p class="body" style="max-width: 1100px; font-size: 36px;">
+            Bring your storymap to the 1:00 PM AI Maker Space. We'll re-aim
+            the workflow at a dataset of your choosing.
+          </p>
+        </div>
+
+        <div class="title-slide-content" style="gap: 12px;">
+          <div class="rule-strong" style="background: rgba(247,244,238,0.4); height: 1px; max-width: 600px;"></div>
+          <div style="display: flex; justify-content: space-between; align-items: flex-end;">
+            <div>
+              <div class="body" style="color: var(--cream); font-weight: 600; font-size: 36px;">Tyson Swetnam, PhD</div>
+              <div class="small mono" style="margin-top: 6px;">tswetnam@arizona.edu · @tswetnam</div>
+            </div>
+            <div class="mono small" style="text-align: right;">
+              BIO5 Institute<br>
+              University of Arizona
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+</deck-stage>
+
+</body>
+</html>

--- a/docs/tutorials/presentations/index.md
+++ b/docs/tutorials/presentations/index.md
@@ -1,0 +1,45 @@
+# Presentation Decks
+
+A small library of HTML slide decks authored for the [UA Public Health & AI Summer School](https://keys.arizona.edu/){target=_blank} 2026. Each deck is a self-contained 1920×1080 presentation that pairs with one or more workshop docs lessons.
+
+## How to view
+
+- Click a deck title below to open it. Use your browser's "open in new tab" if you want the slides visible alongside the docs.
+- **Keyboard:** Arrow keys, space, Page Up / Page Down to navigate. `Home` / `End` jump to start or end. `f` toggles full-screen.
+- **Click navigation:** click the right half of the slide to advance, left half to go back.
+- Each deck remembers your last position via `localStorage` and the URL hash (e.g. `#7` for slide 7) — refresh-safe.
+- **Print to PDF:** your browser's print dialog produces a 1920×1080 PDF with one slide per page.
+
+## Decks
+
+### [Prompt Engineering Basics](prompt-engineering-basics.html){target=_blank}
+
+The 24-slide introduction: how AI models process prompts, the CRAFT framework, advanced techniques (custom instructions, few-shot learning, prompt chaining, multi-modal inputs, web search), and the four common pitfalls every cohort makes.
+
+**Pairs with:** [Prompt Engineering](../../prompts.md)
+
+### [Prompt Engineering Deep Dive — Agentic Workflows](prompt-engineering-deep-dive.html){target=_blank}
+
+The follow-on deck pushing past single prompts into agentic workflows, multi-step orchestration, and the model–tool boundary.
+
+**Pairs with:** [Prompt Engineering](../../prompts.md), [Vibe Coding](../../vibe.md), and [Agentic AI](../../agentic.md)
+
+### [Ethics & Environmental Impact](ethics-and-environmental-impact.html){target=_blank}
+
+Panel deck covering responsible-use frameworks, the civic-grammar argument from Alondra Nelson, regulatory landscape, and the environmental cost of frontier-model training and inference.
+
+**Pairs with:** [Ethics of AI](../../ethics.md), [Bias & Discrimination](../../bias.md), and [Ethical & Legal Considerations](../../legal.md)
+
+### [Geospatial AI for Public Health](geospatial-ai-public-health.html){target=_blank}
+
+Lab deck for the GIS practical: building an interactive story-map of a public-health dataset using an agentic coding workflow.
+
+**Pairs with:** [Vibe coding a Public Health Map](../publichealth/gis.md)
+
+## About the deck shell
+
+These decks use a small custom element, `<deck-stage>`, served alongside the HTML at [`deck-stage.js`](deck-stage.js). It handles canvas scaling, keyboard and click navigation, the slide counter, URL-hash persistence, and print-to-PDF. The full source is short and editable — fork it freely.
+
+## License
+
+All decks are released under [Creative Commons Attribution 4.0](http://creativecommons.org/licenses/by/4.0/){target=_blank}, the same license as the rest of the workshop. Authored for the UA PH&AI Summer School and the [BIO5 KEYS Research Internship](https://keys.arizona.edu/){target=_blank}.

--- a/docs/tutorials/presentations/prompt-engineering-basics.html
+++ b/docs/tutorials/presentations/prompt-engineering-basics.html
@@ -1,0 +1,1495 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>Prompt Engineering Deep Dive — UA PH&amp;AI 2026</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Manrope:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+<script src="deck-stage.js"></script>
+<style>
+  :root {
+    --ua-blue:        #0C234B;
+    --ua-blue-deep:   #07173a;
+    --ua-blue-mid:    #1b3870;
+    --ua-red:         #AB0520;
+    --ua-red-bright:  #c8102e;
+    --cream:          #f7f4ee;
+    --cream-warm:     #efe9dc;
+    --paper:          #fbfaf6;
+    --ink:            #161616;
+    --ink-soft:       #2a2a2a;
+    --mute:           #6b6b6b;
+    --rule:           #d8d2c4;
+    --rule-strong:    #2a2a2a;
+    --code-bg:        #0f1623;
+    --code-fg:        #e6edf3;
+    --good:           #1f7a4d;
+
+    --type-display:   140px;
+    --type-title:     72px;
+    --type-subtitle:  44px;
+    --type-body:      32px;
+    --type-small:     26px;
+    --type-tag:       24px;
+    --type-mono-sm:   24px;
+
+    --pad-x:          110px;
+    --pad-top:        96px;
+    --pad-bottom:     90px;
+    --gap-title:      48px;
+    --gap-item:       28px;
+  }
+
+  html, body { margin: 0; padding: 0; background: #000; }
+  body { font-family: 'Manrope', system-ui, sans-serif; color: var(--ink); }
+
+  deck-stage section {
+    box-sizing: border-box;
+    overflow: hidden;
+    background: var(--cream);
+    color: var(--ink);
+    font-family: 'Manrope', system-ui, sans-serif;
+    font-weight: 400;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  .slide {
+    padding: var(--pad-top) var(--pad-x) var(--pad-bottom);
+    height: 100%;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+  }
+  .slide-dark { background: var(--ua-blue); color: var(--cream); }
+  .slide-paper { background: var(--paper); }
+  .slide-red { background: var(--ua-red); color: var(--cream); }
+
+  .tag {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: var(--type-tag);
+    font-weight: 500;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--ua-red);
+  }
+  .slide-dark .tag { color: var(--cream-warm); opacity: 0.85; }
+  .slide-red .tag { color: var(--cream); opacity: 0.85; }
+
+  .title {
+    font-size: var(--type-title);
+    font-weight: 700;
+    line-height: 1.02;
+    letter-spacing: -0.02em;
+    margin: 0;
+    text-wrap: balance;
+  }
+  .display {
+    font-size: var(--type-display);
+    font-weight: 800;
+    line-height: 0.95;
+    letter-spacing: -0.035em;
+    margin: 0;
+    text-wrap: balance;
+  }
+  .subtitle {
+    font-size: var(--type-subtitle);
+    font-weight: 500;
+    line-height: 1.18;
+    color: var(--ink-soft);
+    margin: 0;
+    text-wrap: pretty;
+  }
+  .slide-dark .subtitle, .slide-red .subtitle { color: var(--cream-warm); }
+  .body {
+    font-size: var(--type-body);
+    font-weight: 400;
+    line-height: 1.42;
+    color: var(--ink-soft);
+    margin: 0;
+    text-wrap: pretty;
+  }
+  .slide-dark .body { color: var(--cream-warm); }
+  .small {
+    font-size: var(--type-small);
+    color: var(--mute);
+    line-height: 1.4;
+  }
+  .slide-dark .small { color: rgba(247,244,238,0.65); }
+  .mono { font-family: 'JetBrains Mono', monospace; }
+
+  .deck-header {
+    position: absolute;
+    top: 38px;
+    left: var(--pad-x);
+    right: var(--pad-x);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--mute);
+  }
+  .slide-dark .deck-header,
+  .slide-red .deck-header { color: rgba(247,244,238,0.55); }
+  .deck-header .lockup { display: flex; align-items: center; gap: 14px; }
+  .deck-header .ua-block {
+    display: inline-block;
+    width: 38px; height: 38px;
+    background: var(--ua-red);
+    color: var(--cream);
+    font-family: 'Manrope', sans-serif;
+    font-weight: 800;
+    font-size: 28px;
+    line-height: 38px;
+    text-align: center;
+    letter-spacing: -0.04em;
+  }
+  .slide-red .deck-header .ua-block { background: var(--cream); color: var(--ua-red); }
+
+  .deck-footer {
+    position: absolute;
+    bottom: 38px;
+    left: var(--pad-x);
+    right: var(--pad-x);
+    display: flex;
+    justify-content: space-between;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--mute);
+  }
+  .slide-dark .deck-footer,
+  .slide-red .deck-footer { color: rgba(247,244,238,0.5); }
+
+  .cols-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 80px; flex: 1; }
+  .cols-2-uneven { display: grid; grid-template-columns: 1.2fr 1fr; gap: 80px; flex: 1; }
+  .cols-3 { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 48px; flex: 1; }
+
+  .checklist { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: var(--gap-item); }
+  .checklist li { display: flex; gap: 22px; font-size: var(--type-body); line-height: 1.35; color: var(--ink-soft); }
+  .checklist .num {
+    flex: 0 0 auto;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 26px;
+    font-weight: 500;
+    color: var(--ua-red);
+    padding-top: 10px;
+    letter-spacing: 0.06em;
+  }
+  .slide-dark .checklist li { color: var(--cream-warm); }
+  .slide-dark .checklist .num { color: var(--cream); opacity: 0.7; }
+
+  .card {
+    background: var(--paper);
+    border: 1px solid var(--rule);
+    padding: 38px 40px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+  .slide-dark .card {
+    background: rgba(255,255,255,0.04);
+    border-color: rgba(247,244,238,0.18);
+    color: var(--cream);
+  }
+  .card h4 {
+    font-size: 36px;
+    font-weight: 700;
+    margin: 0;
+    letter-spacing: -0.01em;
+    line-height: 1.05;
+  }
+  .card p {
+    font-size: 26px;
+    line-height: 1.4;
+    color: var(--ink-soft);
+    margin: 0;
+  }
+  .slide-dark .card p { color: var(--cream-warm); }
+  .card .kicker {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--ua-red);
+  }
+
+  pre.code {
+    background: var(--code-bg);
+    color: var(--code-fg);
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    line-height: 1.5;
+    padding: 36px 42px;
+    margin: 0;
+    border-radius: 4px;
+    overflow: hidden;
+    white-space: pre-wrap;
+  }
+  pre.code .c { color: #8b96a8; }
+  pre.code .k { color: #ffb86c; }
+  pre.code .s { color: #a6e22e; }
+  pre.code .v { color: #79c0ff; }
+  pre.code .x { color: #ff7b72; }
+
+  .rule { height: 1px; background: var(--rule); margin: 0; }
+  .rule-strong { height: 2px; background: var(--ink); margin: 0; }
+  .slide-dark .rule { background: rgba(247,244,238,0.18); }
+  .slide-dark .rule-strong { background: var(--cream); }
+
+  .placeholder {
+    background:
+      repeating-linear-gradient(135deg,
+        rgba(12,35,75,0.06) 0,
+        rgba(12,35,75,0.06) 14px,
+        rgba(12,35,75,0.10) 14px,
+        rgba(12,35,75,0.10) 28px);
+    border: 1px solid var(--rule);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--ink-soft);
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    text-align: center;
+    padding: 24px;
+    box-sizing: border-box;
+  }
+
+  .section-slide {
+    padding: var(--pad-top) var(--pad-x) var(--pad-bottom);
+    height: 100%;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    position: relative;
+  }
+  .section-slide .part-num {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 28px;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    opacity: 0.7;
+    margin-bottom: 36px;
+  }
+  .section-slide .section-title {
+    font-size: 160px;
+    font-weight: 800;
+    line-height: 0.92;
+    letter-spacing: -0.035em;
+    margin: 0;
+    text-wrap: balance;
+  }
+  .section-slide .section-sub {
+    font-size: 36px;
+    font-weight: 400;
+    line-height: 1.3;
+    max-width: 1100px;
+    margin-top: 36px;
+    opacity: 0.85;
+  }
+
+  .title-slide {
+    height: 100%;
+    box-sizing: border-box;
+    padding: var(--pad-top) var(--pad-x) var(--pad-bottom);
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    position: relative;
+  }
+  .title-slide .grid-bg {
+    position: absolute; inset: 0;
+    background-image:
+      linear-gradient(rgba(247,244,238,0.05) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(247,244,238,0.05) 1px, transparent 1px);
+    background-size: 80px 80px;
+    pointer-events: none;
+  }
+  .title-slide-content {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 60px;
+  }
+
+  .step-label {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--ua-red);
+    margin-bottom: 18px;
+  }
+
+  table.surfaces {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 26px;
+  }
+  table.surfaces th, table.surfaces td {
+    text-align: left;
+    padding: 20px 20px;
+    border-bottom: 1px solid var(--rule);
+    vertical-align: top;
+  }
+  table.surfaces th {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--mute);
+    font-weight: 500;
+    border-bottom: 2px solid var(--ink);
+  }
+  table.surfaces td.tool {
+    font-weight: 700;
+    color: var(--ink);
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+  }
+  table.surfaces td.kind {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    color: var(--ua-red);
+  }
+  table.surfaces td.desc { color: var(--ink-soft); font-size: 24px; }
+
+  .stack { display: flex; flex-direction: column; gap: 0; }
+  .stack-row {
+    display: grid;
+    grid-template-columns: 280px 1fr;
+    gap: 40px;
+    padding: 28px 0;
+    border-bottom: 1px solid var(--rule);
+    align-items: baseline;
+  }
+  .stack-row:last-child { border-bottom: none; }
+  .stack-row .label {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    color: var(--ua-red);
+  }
+  .stack-row .val {
+    font-size: 30px;
+    color: var(--ink-soft);
+    line-height: 1.35;
+  }
+  .stack-row .val strong { color: var(--ink); font-weight: 700; }
+
+  /* Pipeline pills */
+  .pipeline {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 18px;
+  }
+  .pipe {
+    border: 1px solid var(--rule);
+    background: var(--paper);
+    padding: 28px 26px;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+  }
+  .pipe .num {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    letter-spacing: 0.14em;
+    color: var(--ua-red);
+  }
+  .pipe h5 {
+    margin: 0;
+    font-size: 30px;
+    font-weight: 700;
+    letter-spacing: -0.01em;
+    line-height: 1.05;
+  }
+  .pipe p { margin: 0; font-size: 24px; line-height: 1.4; color: var(--ink-soft); }
+  .pipe.hi {
+    background: var(--ua-blue);
+    border-color: var(--ua-blue);
+    color: var(--cream);
+  }
+  .pipe.hi h5 { color: var(--cream); }
+  .pipe.hi p { color: var(--cream-warm); }
+  .pipe.hi .num { color: var(--cream-warm); }
+
+  /* CRAFT letter monogram */
+  .craft-letter {
+    font-size: 360px;
+    font-weight: 800;
+    line-height: 0.85;
+    letter-spacing: -0.05em;
+    color: var(--ua-red);
+  }
+  .slide-dark .craft-letter { color: var(--cream); }
+
+  /* Good/Bad badges */
+  .bad-good { display: grid; grid-template-columns: 1fr 1fr; gap: 32px; }
+  .bg-card {
+    background: var(--paper);
+    border: 1px solid var(--rule);
+    padding: 32px 36px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+  .bg-card .badge {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    padding: 6px 14px;
+    align-self: flex-start;
+  }
+  .bg-card.bad { border-left: 6px solid var(--ua-red); }
+  .bg-card.bad .badge { background: var(--ua-red); color: var(--cream); }
+  .bg-card.good { border-left: 6px solid var(--good); }
+  .bg-card.good .badge { background: var(--good); color: var(--cream); }
+  .bg-card .quote {
+    font-size: 28px;
+    line-height: 1.4;
+    color: var(--ink-soft);
+    font-family: 'JetBrains Mono', monospace;
+  }
+</style>
+</head>
+<body>
+
+<deck-stage width="1920" height="1080">
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       1 · TITLE SLIDE
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="01 Title" class="slide-dark">
+    <div class="title-slide">
+      <div class="grid-bg"></div>
+      <div class="deck-header">
+        <div class="lockup">
+          <span class="ua-block">A</span>
+          <span>University of Arizona · BIO5 Institute</span>
+        </div>
+        <div>PH&amp;AI Summer School · 2nd Edition</div>
+      </div>
+
+      <div class="title-slide-content" style="margin-top: 60px;">
+        <div class="tag" style="font-size: 26px;">AI Fluency Track · Deep Dive</div>
+        <h1 class="display" style="font-size: 168px;">
+          Prompt<br>Engineering,<br><span style="color: var(--ua-red-bright);">on purpose.</span>
+        </h1>
+      </div>
+
+      <div class="title-slide-content" style="gap: 12px;">
+        <div class="rule-strong" style="background: rgba(247,244,238,0.4); height: 1px; max-width: 600px;"></div>
+        <div style="display: flex; justify-content: space-between; align-items: flex-end;">
+          <div>
+            <div class="body" style="color: var(--cream); font-weight: 600; font-size: 36px;">Tyson Swetnam, PhD</div>
+            <div class="small" style="margin-top: 6px;">Associate Professor · BIO5 Institute</div>
+          </div>
+          <div class="mono small" style="text-align: right;">
+            Grand Challenges Research Building<br>
+            Tucson, AZ · June 2026
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       2 · WHAT YOU'LL LEAVE WITH
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="02 Outcome">
+    <div class="slide">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>02 / Outcome</div>
+      </div>
+
+      <div class="cols-2-uneven" style="margin-top: 70px;">
+        <div style="display: flex; flex-direction: column; justify-content: center;">
+          <div class="tag">What You'll Leave With</div>
+          <h2 class="title" style="margin-top: 24px;">Four things, transferable across every chat window you open.</h2>
+          <p class="body" style="margin-top: 36px; max-width: 720px;">
+            This deck mirrors <span class="mono" style="color: var(--ua-red); font-size: 28px;">intro-gpt/prompts/</span>.
+            Pull it up alongside — every section in the slides has a deeper write-up there.
+          </p>
+        </div>
+        <ul class="checklist" style="align-self: center;">
+          <li><span class="num">01</span><div><strong style="color: var(--ink);">Fundamentals.</strong> How AI models actually process and respond to prompts.</div></li>
+          <li><span class="num">02</span><div><strong style="color: var(--ink);">Modern features.</strong> Document upload, web search, multi-modal inputs.</div></li>
+          <li><span class="num">03</span><div><strong style="color: var(--ink);">Best practices.</strong> Structured approaches to writing effective prompts.</div></li>
+          <li><span class="num">04</span><div><strong style="color: var(--ink);">Advanced techniques.</strong> Context management, chaining, custom instructions.</div></li>
+        </ul>
+      </div>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>02 · OUTCOME</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       3 · SECTION DIVIDER · PART 1
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="03 Part 1 Divider" class="slide-dark">
+    <div class="section-slide">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>Part 01 · Mental Model</div>
+      </div>
+      <div>
+        <div class="part-num">Part 01</div>
+        <h2 class="section-title">What the model<br>actually sees.</h2>
+        <p class="section-sub">
+          Five stages from your keystrokes to its first token. Skip this and you'll
+          spend the rest of your career arguing with a black box.
+        </p>
+      </div>
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>03 · PART 01</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       4 · THE PROCESSING PIPELINE
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="04 Pipeline">
+    <div class="slide">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>04 / The Pipeline</div>
+      </div>
+
+      <div class="tag" style="margin-top: 40px;">How AI Models Process Your Input</div>
+      <h2 class="title" style="margin-top: 24px; max-width: 1500px;">Five stages between your keystrokes and the first generated token.</h2>
+
+      <div class="pipeline" style="margin-top: 90px;">
+        <div class="pipe">
+          <div class="num">01</div>
+          <h5>Tokenization.</h5>
+          <p>Your prompt is broken into smaller units — tokens. Whitespace, punctuation, sub-words.</p>
+        </div>
+        <div class="pipe">
+          <div class="num">02</div>
+          <h5>Context assembly.</h5>
+          <p>Uploaded documents and prior conversation are stitched in alongside your message.</p>
+        </div>
+        <div class="pipe hi">
+          <div class="num">03</div>
+          <h5>Attention.</h5>
+          <p>The model weighs which parts of that context matter for the next token. This is where prompt phrasing pays off.</p>
+        </div>
+        <div class="pipe">
+          <div class="num">04</div>
+          <h5>Generation.</h5>
+          <p>Response is produced token by token, conditioned on everything seen so far.</p>
+        </div>
+        <div class="pipe">
+          <div class="num">05</div>
+          <h5>Formatting.</h5>
+          <p>Output is structured according to your specifications — markdown, JSON, code blocks.</p>
+        </div>
+      </div>
+
+      <p class="small" style="margin-top: 80px; max-width: 1400px;">
+        Most "the AI didn't listen" complaints are actually stage 03 problems: the relevant
+        instruction was buried in a wall of context, and the model attended to something else.
+      </p>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>04 · PIPELINE</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       5 · CAPABILITY LANDSCAPE
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="05 Capability Table" class="slide-paper">
+    <div class="slide slide-paper">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>05 / Tooling 2026</div>
+      </div>
+
+      <div class="tag" style="margin-top: 40px;">Core Features of Today's AI Tools</div>
+      <h2 class="title" style="margin-top: 24px; max-width: 1600px;">The picture in mid-2026 — pick the surface that matches the job.</h2>
+
+      <table class="surfaces" style="margin-top: 56px;">
+        <thead>
+          <tr>
+            <th>Feature</th>
+            <th>Claude</th>
+            <th>ChatGPT</th>
+            <th>Gemini</th>
+            <th>NotebookLM</th>
+            <th>Copilot</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td class="tool">Document upload</td>
+            <td class="desc">PDFs, text, code</td>
+            <td class="desc">PDFs, images, data</td>
+            <td class="desc">PDFs, images, GDrive</td>
+            <td class="desc">PDFs, Google Docs</td>
+            <td class="desc">PDFs, OneDrive</td>
+          </tr>
+          <tr>
+            <td class="tool">Web search</td>
+            <td class="kind">via MCP</td>
+            <td class="desc">Yes</td>
+            <td class="desc">Yes</td>
+            <td class="desc">Yes</td>
+            <td class="desc">Yes</td>
+          </tr>
+          <tr>
+            <td class="tool">Context window</td>
+            <td class="kind">200K</td>
+            <td class="kind">128K</td>
+            <td class="kind">2M</td>
+            <td class="desc">Document-based</td>
+            <td class="kind">128K</td>
+          </tr>
+          <tr>
+            <td class="tool">File analysis</td>
+            <td class="desc">Yes</td>
+            <td class="desc">Yes</td>
+            <td class="desc">Yes</td>
+            <td class="desc">Deep analysis</td>
+            <td class="desc">Yes</td>
+          </tr>
+          <tr>
+            <td class="tool">Code execution</td>
+            <td class="kind">Yes (MCP)</td>
+            <td class="desc">Yes</td>
+            <td class="desc">Yes</td>
+            <td class="desc" style="color: var(--mute);">No</td>
+            <td class="desc">Yes</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <p class="small" style="margin-top: 50px; max-width: 1500px;">
+        Context-window size is rarely the bottleneck — placement and phrasing inside it usually are.
+        A 2M-token window does not exempt you from CRAFT.
+      </p>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>05 · TOOLING</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       6 · GOOD / BETTER / BEST
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="06 Good Better Best">
+    <div class="slide">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>06 / Anatomy</div>
+      </div>
+
+      <div class="tag" style="margin-top: 40px;">The Foundation · Clear Instructions</div>
+      <h2 class="title" style="margin-top: 24px; max-width: 1600px;">Same task, three drafts. Watch the prompt grow a spine.</h2>
+
+      <div class="cols-3" style="margin-top: 48px; gap: 36px;">
+        <div style="display: flex; flex-direction: column; gap: 14px;">
+          <div class="step-label" style="margin-bottom: 0;">Basic</div>
+          <pre class="code" style="font-size: 24px; padding: 22px 24px; line-height: 1.35;"><span class="c"># Basic</span>
+<span class="s">"Summarize this
+research paper
+in 3 bullet points"</span></pre>
+          <p class="small" style="font-size: 24px;">A request. No role. No structure. You can't predict what you'll get.</p>
+        </div>
+        <div style="display: flex; flex-direction: column; gap: 14px;">
+          <div class="step-label" style="margin-bottom: 0; color: var(--ink);">Better</div>
+          <pre class="code" style="font-size: 24px; padding: 22px 24px; line-height: 1.35;"><span class="c"># Better</span>
+<span class="s">"As a research
+scientist, summarize
+the key findings
+from this paper in
+3 bullets, focusing
+on methodology and
+results"</span></pre>
+          <p class="small" style="font-size: 24px;">Adds a <strong style="color: var(--ink);">role</strong> and a <strong style="color: var(--ink);">focus</strong>.</p>
+        </div>
+        <div style="display: flex; flex-direction: column; gap: 14px;">
+          <div class="step-label" style="margin-bottom: 0; color: var(--good);">Best</div>
+          <pre class="code" style="font-size: 24px; padding: 22px 24px; line-height: 1.35;"><span class="c"># Best</span>
+<span class="s">"You are a research
+scientist reviewing
+for a journal.
+Summarize the PDF
+in 3 bullets:
+1. Q &amp; hypothesis
+2. Methods &amp; n
+3. Findings &amp; limits
+Format as a list."</span></pre>
+          <p class="small" style="font-size: 24px;">Role · audience · scope · format. Reproducible.</p>
+        </div>
+      </div>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>06 · ANATOMY</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       7 · SECTION DIVIDER · PART 2 — CRAFT
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="07 Part 2 Divider" class="slide-red">
+    <div class="section-slide">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>Part 02 · The CRAFT Framework</div>
+      </div>
+      <div>
+        <div class="part-num">Part 02</div>
+        <h2 class="section-title">C·R·A·F·T</h2>
+        <p class="section-sub">
+          Context · Role · Action · Format · Tone. Five fields. One mnemonic.
+          The fastest way to make a prompt reproducible.
+        </p>
+      </div>
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>07 · PART 02</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       8 · CRAFT · CONTEXT
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="08 CRAFT Context">
+    <div class="slide">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>08 / CRAFT · 01</div>
+      </div>
+
+      <div class="cols-2-uneven" style="margin-top: 70px;">
+        <div style="display: flex; flex-direction: column; justify-content: center;">
+          <div class="craft-letter">C.</div>
+        </div>
+        <div style="display: flex; flex-direction: column; justify-content: center;">
+          <div class="tag">01 · Context</div>
+          <h2 class="title" style="margin-top: 20px;">Set the scene.</h2>
+          <p class="body" style="margin-top: 32px;">
+            Provide background information. What project is this? Who is the audience?
+            What's the upstream goal that this prompt serves?
+          </p>
+          <div class="card" style="margin-top: 40px;">
+            <div class="kicker">In practice</div>
+            <p style="font-size: 26px; font-family: 'JetBrains Mono', monospace;">"I'm preparing a grant proposal for NSF funding on AI in education…"</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>08 · CONTEXT</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       9 · CRAFT · ROLE
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="09 CRAFT Role" class="slide-paper">
+    <div class="slide slide-paper">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>09 / CRAFT · 02</div>
+      </div>
+
+      <div class="cols-2-uneven" style="margin-top: 70px;">
+        <div style="display: flex; flex-direction: column; justify-content: center;">
+          <div class="craft-letter">R.</div>
+        </div>
+        <div style="display: flex; flex-direction: column; justify-content: center;">
+          <div class="tag">02 · Role</div>
+          <h2 class="title" style="margin-top: 20px;">Define who the AI is.</h2>
+          <p class="body" style="margin-top: 32px;">
+            A role anchors the model to a register, a vocabulary, and a set of priors.
+            "Grant writer" produces different prose than "tweet writer", even with the same task.
+          </p>
+          <div class="card" style="margin-top: 40px;">
+            <div class="kicker">In practice</div>
+            <p style="font-size: 26px; font-family: 'JetBrains Mono', monospace;">"Act as an experienced grant writer and education researcher…"</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>09 · ROLE</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       10 · CRAFT · ACTION
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="10 CRAFT Action">
+    <div class="slide">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>10 / CRAFT · 03</div>
+      </div>
+
+      <div class="cols-2-uneven" style="margin-top: 70px;">
+        <div style="display: flex; flex-direction: column; justify-content: center;">
+          <div class="craft-letter">A.</div>
+        </div>
+        <div style="display: flex; flex-direction: column; justify-content: center;">
+          <div class="tag">03 · Action</div>
+          <h2 class="title" style="margin-top: 20px;">Specify the verb.</h2>
+          <p class="body" style="margin-top: 32px;">
+            One unambiguous task. "Review" is not "rewrite". "Summarize" is not "expand".
+            If you need three actions, number them.
+          </p>
+          <div class="card" style="margin-top: 40px;">
+            <div class="kicker">In practice</div>
+            <p style="font-size: 26px; font-family: 'JetBrains Mono', monospace;">"Review my draft introduction and suggest improvements…"</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>10 · ACTION</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       11 · CRAFT · FORMAT
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="11 CRAFT Format" class="slide-paper">
+    <div class="slide slide-paper">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>11 / CRAFT · 04</div>
+      </div>
+
+      <div class="cols-2-uneven" style="margin-top: 70px;">
+        <div style="display: flex; flex-direction: column; justify-content: center;">
+          <div class="craft-letter">F.</div>
+        </div>
+        <div style="display: flex; flex-direction: column; justify-content: center;">
+          <div class="tag">04 · Format</div>
+          <h2 class="title" style="margin-top: 20px;">Describe the shape.</h2>
+          <p class="body" style="margin-top: 32px;">
+            Markdown headers, bulleted lists, a comparison table, a JSON object,
+            tracked-changes. The model will pick a default if you don't — and you usually won't like it.
+          </p>
+          <div class="card" style="margin-top: 40px;">
+            <div class="kicker">In practice</div>
+            <p style="font-size: 26px; font-family: 'JetBrains Mono', monospace;">"Provide feedback as tracked changes with explanations…"</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>11 · FORMAT</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       12 · CRAFT · TONE
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="12 CRAFT Tone">
+    <div class="slide">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>12 / CRAFT · 05</div>
+      </div>
+
+      <div class="cols-2-uneven" style="margin-top: 70px;">
+        <div style="display: flex; flex-direction: column; justify-content: center;">
+          <div class="craft-letter">T.</div>
+        </div>
+        <div style="display: flex; flex-direction: column; justify-content: center;">
+          <div class="tag">05 · Tone</div>
+          <h2 class="title" style="margin-top: 20px;">Indicate style and voice.</h2>
+          <p class="body" style="margin-top: 32px;">
+            Professional · constructive · skeptical · plain-English-for-a-policymaker. Tone is
+            the one CRAFT field most people skip — and it's the difference between usable and rewriting from scratch.
+          </p>
+          <div class="card" style="margin-top: 40px;">
+            <div class="kicker">In practice</div>
+            <p style="font-size: 26px; font-family: 'JetBrains Mono', monospace;">"Professional, constructive, and encouraging."</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>12 · TONE</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       13 · CRAFT EXAMPLE — ALL TOGETHER
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="13 CRAFT Example" class="slide-dark">
+    <div class="slide slide-dark">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>13 / CRAFT in Full</div>
+      </div>
+
+      <div class="tag" style="margin-top: 40px; color: var(--cream-warm);">CRAFT · Worked Example</div>
+      <h2 class="title" style="margin-top: 24px; color: var(--cream); max-width: 1600px;">All five fields, one prompt, copy-able.</h2>
+
+      <div class="cols-2-uneven" style="margin-top: 56px;">
+        <pre class="code" style="font-size: 24px;"><span class="x">Context:</span> I'm preparing a grant proposal
+   for NSF funding on AI in education.
+
+<span class="x">Role:</span>    Act as an experienced grant
+   writer and education researcher.
+
+<span class="x">Action:</span>  Review my draft introduction
+   and suggest improvements.
+
+<span class="x">Format:</span>  Provide feedback as tracked
+   changes with explanations.
+
+<span class="x">Tone:</span>    Professional, constructive,
+   and encouraging.</pre>
+        <div style="display: flex; flex-direction: column; gap: 24px; justify-content: center;">
+          <div class="card" style="background: rgba(255,255,255,0.04); border-color: rgba(247,244,238,0.18);">
+            <div class="kicker" style="color: var(--cream-warm);">Why it works</div>
+            <p style="color: var(--cream-warm); font-size: 26px;">Every field constrains a different degree of freedom.
+            The model has nowhere to drift.</p>
+          </div>
+          <div class="card" style="background: rgba(255,255,255,0.04); border-color: rgba(247,244,238,0.18);">
+            <div class="kicker" style="color: var(--cream-warm);">Save it</div>
+            <p style="color: var(--cream-warm); font-size: 26px;">A reusable CRAFT block becomes a custom instruction,
+            a Project, or a prompt template.</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>13 · CRAFT FULL</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       14 · SECTION DIVIDER · PART 3 — ADVANCED
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="14 Part 3 Divider" class="slide-dark">
+    <div class="section-slide">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>Part 03 · Advanced Techniques</div>
+      </div>
+      <div>
+        <div class="part-num">Part 03</div>
+        <h2 class="section-title">Past the<br>single prompt.</h2>
+        <p class="section-sub">
+          System instructions · few-shot · chaining · multi-modal · web search.
+          The vocabulary you need to recognize, even if you only use three of them this month.
+        </p>
+      </div>
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>14 · PART 03</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       15 · CUSTOM INSTRUCTIONS / SYSTEM PROMPTS
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="15 Custom Instructions">
+    <div class="slide">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>15 / Technique 01</div>
+      </div>
+
+      <div class="step-label" style="margin-top: 40px;">Technique 01</div>
+      <h2 class="title" style="margin-top: 8px; max-width: 1600px;">Custom instructions: CRAFT, but persistent.</h2>
+
+      <div class="cols-2-uneven" style="margin-top: 50px;">
+        <pre class="code" style="font-size: 24px;"><span class="c"># Project Context</span>
+I'm a data scientist working on
+machine learning projects.
+Always provide Python code examples
+using scikit-learn and pandas.
+Include docstrings and type hints
+in all code.
+
+<span class="c"># Response Preferences</span>
+- Be concise but thorough
+- Explain complex concepts with analogies
+- Always cite sources when making
+  factual claims</pre>
+        <div style="display: flex; flex-direction: column; gap: 24px; justify-content: center;">
+          <div class="card">
+            <div class="kicker">Where it lives</div>
+            <div style="display: grid; grid-template-columns: 120px 1fr; gap: 8px 20px; font-size: 26px; line-height: 1.4;">
+              <div style="font-weight: 600; color: var(--ink);">Claude</div><div style="color: var(--ink-soft);">System Instructions</div>
+              <div style="font-weight: 600; color: var(--ink);">Gemini</div><div style="color: var(--ink-soft);">Custom Instructions</div>
+              <div style="font-weight: 600; color: var(--ink);">ChatGPT</div><div style="color: var(--ink-soft);">Custom GPTs or Projects</div>
+            </div>
+          </div>
+          <div class="card">
+            <div class="kicker">Why bother</div>
+            <p style="font-size: 26px;">It becomes a global rule applied to every prompt that follows — your defaults move up to the platform layer, not the chat.</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>15 · SYSTEM PROMPTS</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       16 · FEW-SHOT
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="16 Few-Shot" class="slide-paper">
+    <div class="slide slide-paper">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>16 / Technique 02</div>
+      </div>
+
+      <div class="step-label" style="margin-top: 40px;">Technique 02 — Few-shot learning</div>
+      <h2 class="title" style="margin-top: 8px; max-width: 1600px;">Show, don't tell. Three labeled examples beat a paragraph of instructions.</h2>
+
+      <div class="cols-2-uneven" style="margin-top: 50px;">
+        <pre class="code" style="font-size: 24px;">I need to classify customer feedback.
+Here are examples:
+
+<span class="s">"The product arrived damaged"</span>
+   → Category: <span class="v">Shipping Issue</span>
+<span class="s">"Can't log into my account"</span>
+   → Category: <span class="v">Technical Support</span>
+<span class="s">"Love the new features!"</span>
+   → Category: <span class="v">Positive Feedback</span>
+
+Now classify these:
+1. "The app keeps crashing on startup"
+2. "Best purchase I've made this year"
+3. "Package was left in the rain"</pre>
+        <div style="display: flex; flex-direction: column; gap: 24px; justify-content: center;">
+          <div class="card">
+            <div class="kicker">Rule of thumb</div>
+            <p style="font-size: 26px;">3–5 examples is the sweet spot. Cover the corners of the label space, not just the easy cases.</p>
+          </div>
+          <div class="card" style="border-color: var(--ua-red);">
+            <div class="kicker">Public-health twist</div>
+            <p style="font-size: 26px;">Few-shot is how you teach a model your local ICD coding shorthand, your survey response taxonomy, or your team's review rubric — without fine-tuning.</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>16 · FEW-SHOT</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       17 · PROMPT CHAINING
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="17 Chaining">
+    <div class="slide">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>17 / Technique 03</div>
+      </div>
+
+      <div class="step-label" style="margin-top: 40px;">Technique 03 — Prompt chaining</div>
+      <h2 class="title" style="margin-top: 8px; max-width: 1600px;">Build complex outputs through a sequence — not one mega-prompt.</h2>
+
+      <div class="stack" style="margin-top: 80px;">
+        <div class="stack-row" style="grid-template-columns: 260px 200px 1fr;">
+          <div class="label">Start broad</div>
+          <div class="mono small" style="color: var(--ua-red);">prompt 01</div>
+          <div class="val">"Outline a research paper on sustainable AI."</div>
+        </div>
+        <div class="stack-row" style="grid-template-columns: 260px 200px 1fr;">
+          <div class="label">Zoom in</div>
+          <div class="mono small" style="color: var(--ua-red);">prompt 02</div>
+          <div class="val">"Expand section 3 on energy-efficient training methods."</div>
+        </div>
+        <div class="stack-row" style="grid-template-columns: 260px 200px 1fr;">
+          <div class="label">Refine</div>
+          <div class="mono small" style="color: var(--ua-red);">prompt 03</div>
+          <div class="val">"Add citations and make the tone more academic."</div>
+        </div>
+        <div class="stack-row" style="grid-template-columns: 260px 200px 1fr;">
+          <div class="label">Polish</div>
+          <div class="mono small" style="color: var(--ua-red);">prompt 04</div>
+          <div class="val">"Format according to IEEE standards."</div>
+        </div>
+      </div>
+
+      <p class="small" style="margin-top: 60px; max-width: 1400px;">
+        Each turn corrects course. You're trading one undirected lottery ticket
+        for four checkpoints where you can intervene.
+      </p>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>17 · CHAINING</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       18 · MULTI-MODAL + WEB SEARCH
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="18 Multimodal Search" class="slide-paper">
+    <div class="slide slide-paper">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>18 / Techniques 04 + 05</div>
+      </div>
+
+      <div class="tag" style="margin-top: 40px;">Combining inputs &amp; live retrieval</div>
+      <h2 class="title" style="margin-top: 24px; max-width: 1600px;">Multi-modal prompting and web search — the two cheat codes most people leave on the table.</h2>
+
+      <div class="cols-2" style="margin-top: 40px; gap: 60px; flex: 0 1 auto;">
+        <div style="display: flex; flex-direction: column; gap: 18px; min-height: 0;">
+          <div class="step-label" style="margin-bottom: 0;">Technique 04 — Multi-modal</div>
+          <pre class="code" style="font-size: 24px; line-height: 1.4; padding: 28px 32px;">I've uploaded:
+1. A screenshot of my dashboard
+2. The underlying data in CSV
+3. Our brand guidelines PDF
+
+Create a redesigned dashboard:
+- improve data viz
+- adhere to our brand colors
+- highlight the data-dict KPIs</pre>
+          <p class="small" style="font-size: 24px;">A single prompt that sees pixels, rows, and rules at once.</p>
+        </div>
+        <div style="display: flex; flex-direction: column; gap: 18px; min-height: 0;">
+          <div class="step-label" style="margin-bottom: 0;">Technique 05 — Web search</div>
+          <pre class="code" style="font-size: 24px; line-height: 1.4; padding: 28px 32px;">Search for the latest research on
+the public health benefits of
+vaccination published in 2024.
+
+Focus on:
+- Top conferences (AHA, ASPPH)
+- mRNA, Bird Flu, COVID
+
+Summarize the top 5 with links.</pre>
+          <p class="small" style="font-size: 24px;">Pair retrieval with a citation requirement — or you get confident summaries with no source trail.</p>
+        </div>
+      </div>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>18 · MULTI-MODAL + SEARCH</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       19 · SECTION DIVIDER · PART 4 — PITFALLS
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="19 Part 4 Divider" class="slide-red">
+    <div class="section-slide">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>Part 04 · Common Pitfalls</div>
+      </div>
+      <div>
+        <div class="part-num">Part 04</div>
+        <h2 class="section-title">Four ways<br>to fail.</h2>
+        <p class="section-sub">
+          The mistakes that show up in every workshop, every cohort, every project —
+          and the small rewrites that fix them.
+        </p>
+      </div>
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>19 · PART 04</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       20 · PITFALLS · VAGUE / OVERLOAD
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="20 Pitfalls 1-2">
+    <div class="slide">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>20 / Pitfalls 01–02</div>
+      </div>
+
+      <div class="tag" style="margin-top: 40px;">The most common rewrites</div>
+      <h2 class="title" style="margin-top: 24px; max-width: 1600px;">Vague instructions &amp; information overload.</h2>
+
+      <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 32px; margin-top: 60px;">
+        <div>
+          <div class="step-label" style="margin-bottom: 12px;">Pitfall 01 — Vague instructions</div>
+          <div class="bad-good" style="grid-template-columns: 1fr;">
+            <div class="bg-card bad">
+              <span class="badge">Poor</span>
+              <p class="quote">"Make this better."</p>
+            </div>
+            <div class="bg-card good">
+              <span class="badge">Better</span>
+              <p class="quote">"Improve this abstract by making it more concise (under 250 words), adding keywords, and ensuring it follows the journal's structure: background, methods, results, conclusions."</p>
+            </div>
+          </div>
+        </div>
+        <div>
+          <div class="step-label" style="margin-bottom: 12px;">Pitfall 02 — Information overload</div>
+          <div class="bad-good" style="grid-template-columns: 1fr;">
+            <div class="bg-card bad">
+              <span class="badge">Poor</span>
+              <p class="quote">Uploading 50 documents without guidance.</p>
+            </div>
+            <div class="bg-card good">
+              <span class="badge">Better</span>
+              <p class="quote">"Focus on documents 1–3 which contain the methodology. Ignore the appendices."</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>20 · PITFALLS 01–02</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       21 · PITFALLS · ASSUMING / NO FORMAT
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="21 Pitfalls 3-4" class="slide-paper">
+    <div class="slide slide-paper">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>21 / Pitfalls 03–04</div>
+      </div>
+
+      <div class="tag" style="margin-top: 40px;">The other two everyone makes</div>
+      <h2 class="title" style="margin-top: 24px; max-width: 1600px;">Assuming knowledge &amp; leaving the format up to the model.</h2>
+
+      <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 32px; margin-top: 60px;">
+        <div>
+          <div class="step-label" style="margin-bottom: 12px;">Pitfall 03 — Assuming knowledge</div>
+          <div class="bad-good" style="grid-template-columns: 1fr;">
+            <div class="bg-card bad">
+              <span class="badge">Poor</span>
+              <p class="quote">"Fix the usual issues."</p>
+            </div>
+            <div class="bg-card good">
+              <span class="badge">Better</span>
+              <p class="quote">"Check for: passive voice, sentences over 25 words, undefined acronyms, and missing Oxford commas."</p>
+            </div>
+          </div>
+        </div>
+        <div>
+          <div class="step-label" style="margin-bottom: 12px;">Pitfall 04 — No output format</div>
+          <div class="bad-good" style="grid-template-columns: 1fr;">
+            <div class="bg-card bad">
+              <span class="badge">Poor</span>
+              <p class="quote">"Summarize this."</p>
+            </div>
+            <div class="bg-card good">
+              <span class="badge">Better</span>
+              <p class="quote">"Create an executive summary with: a 3-sentence overview, 5 key points as bullets, 1 paragraph on implications, formatted with markdown headers."</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>21 · PITFALLS 03–04</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       22 · CHECKLIST
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="22 Checklist">
+    <div class="slide">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>22 / Quick Reference</div>
+      </div>
+
+      <div class="tag" style="margin-top: 40px;">Tape This Above Your Monitor</div>
+      <h2 class="title" style="margin-top: 24px; max-width: 1500px;">Nine boxes. Run them before you hit return.</h2>
+
+      <div style="display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 22px 60px; margin-top: 80px;">
+        <div style="display: flex; gap: 20px; align-items: flex-start;">
+          <div class="mono" style="font-size: 26px; color: var(--ua-red);">[&nbsp;]</div>
+          <div><strong style="font-size: 28px;">Clear objective.</strong><div class="small">What do you want to achieve?</div></div>
+        </div>
+        <div style="display: flex; gap: 20px; align-items: flex-start;">
+          <div class="mono" style="font-size: 26px; color: var(--ua-red);">[&nbsp;]</div>
+          <div><strong style="font-size: 28px;">Context provided.</strong><div class="small">Background included?</div></div>
+        </div>
+        <div style="display: flex; gap: 20px; align-items: flex-start;">
+          <div class="mono" style="font-size: 26px; color: var(--ua-red);">[&nbsp;]</div>
+          <div><strong style="font-size: 28px;">Role defined.</strong><div class="small">Who should the AI act as?</div></div>
+        </div>
+        <div style="display: flex; gap: 20px; align-items: flex-start;">
+          <div class="mono" style="font-size: 26px; color: var(--ua-red);">[&nbsp;]</div>
+          <div><strong style="font-size: 28px;">Specific action.</strong><div class="small">Exact task described?</div></div>
+        </div>
+        <div style="display: flex; gap: 20px; align-items: flex-start;">
+          <div class="mono" style="font-size: 26px; color: var(--ua-red);">[&nbsp;]</div>
+          <div><strong style="font-size: 28px;">Output format.</strong><div class="small">Structure specified?</div></div>
+        </div>
+        <div style="display: flex; gap: 20px; align-items: flex-start;">
+          <div class="mono" style="font-size: 26px; color: var(--ua-red);">[&nbsp;]</div>
+          <div><strong style="font-size: 28px;">Examples given.</strong><div class="small">For complex tasks?</div></div>
+        </div>
+        <div style="display: flex; gap: 20px; align-items: flex-start;">
+          <div class="mono" style="font-size: 26px; color: var(--ua-red);">[&nbsp;]</div>
+          <div><strong style="font-size: 28px;">Constraints noted.</strong><div class="small">Length, style, content limits?</div></div>
+        </div>
+        <div style="display: flex; gap: 20px; align-items: flex-start;">
+          <div class="mono" style="font-size: 26px; color: var(--ua-red);">[&nbsp;]</div>
+          <div><strong style="font-size: 28px;">Documents referenced.</strong><div class="small">If using uploads?</div></div>
+        </div>
+        <div style="display: flex; gap: 20px; align-items: flex-start;">
+          <div class="mono" style="font-size: 26px; color: var(--ua-red);">[&nbsp;]</div>
+          <div><strong style="font-size: 28px;">Follow-up planned.</strong><div class="small">For iterative improvement?</div></div>
+        </div>
+      </div>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>22 · CHECKLIST</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       23 · RESOURCES
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="23 Resources" class="slide-paper">
+    <div class="slide slide-paper">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>23 / Resources</div>
+      </div>
+
+      <div class="tag" style="margin-top: 40px;">Bookmarks</div>
+      <h2 class="title" style="margin-top: 24px; max-width: 1500px;">Everything from today, plus the deeper write-ups.</h2>
+
+      <div class="stack" style="margin-top: 70px;">
+        <div class="stack-row">
+          <div class="label">This Page</div>
+          <div class="val mono" style="color: var(--ua-red); font-size: 26px;">tyson-swetnam.github.io/intro-gpt/prompts/</div>
+        </div>
+        <div class="stack-row">
+          <div class="label">Full Workshop</div>
+          <div class="val mono" style="color: var(--ua-red); font-size: 26px;">tyson-swetnam.github.io/intro-gpt/</div>
+        </div>
+        <div class="stack-row">
+          <div class="label">Anthropic</div>
+          <div class="val mono" style="color: var(--ua-red); font-size: 26px;">docs.anthropic.com/claude/docs/prompt-engineering</div>
+        </div>
+        <div class="stack-row">
+          <div class="label">OpenAI</div>
+          <div class="val mono" style="color: var(--ua-red); font-size: 26px;">platform.openai.com/docs/guides/prompt-engineering</div>
+        </div>
+        <div class="stack-row">
+          <div class="label">Google</div>
+          <div class="val mono" style="color: var(--ua-red); font-size: 26px;">ai.google.dev/gemini-api/docs/prompting-strategies</div>
+        </div>
+        <div class="stack-row">
+          <div class="label">Learn Prompting</div>
+          <div class="val mono" style="color: var(--ua-red); font-size: 26px;">learnprompting.org</div>
+        </div>
+      </div>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>23 · RESOURCES</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       24 · Q&A / THANK YOU
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="24 Thank You" class="slide-dark">
+    <div class="slide slide-dark">
+      <div class="title-slide">
+        <div class="grid-bg"></div>
+        <div class="deck-header">
+          <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+          <div>End · Q&amp;A</div>
+        </div>
+
+        <div class="title-slide-content" style="margin-top: 0;">
+          <div class="tag" style="color: var(--cream-warm);">Open the lab notebook</div>
+          <h2 class="display" style="font-size: 200px;">
+            Now you<br>try one<span style="color: var(--ua-red-bright);">.</span>
+          </h2>
+          <p class="body" style="max-width: 1100px; font-size: 36px;">
+            Pull up a chat window. Pick a task from your week. Write it CRAFT-style.
+            Compare it to the version you'd have typed an hour ago.
+          </p>
+        </div>
+
+        <div class="title-slide-content" style="gap: 12px;">
+          <div class="rule-strong" style="background: rgba(247,244,238,0.4); height: 1px; max-width: 600px;"></div>
+          <div style="display: flex; justify-content: space-between; align-items: flex-end;">
+            <div>
+              <div class="body" style="color: var(--cream); font-weight: 600; font-size: 36px;">Tyson Swetnam, PhD</div>
+              <div class="small mono" style="margin-top: 6px;">tswetnam@arizona.edu · @tswetnam</div>
+            </div>
+            <div class="mono small" style="text-align: right;">
+              BIO5 Institute<br>
+              University of Arizona
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+</deck-stage>
+
+</body>
+</html>

--- a/docs/tutorials/presentations/prompt-engineering-deep-dive.html
+++ b/docs/tutorials/presentations/prompt-engineering-deep-dive.html
@@ -1,0 +1,1763 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>Prompt Engineering Deep Dive — Agentic Workflows · UA PH&amp;AI 2026</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Manrope:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+<script src="deck-stage.js"></script>
+<style>
+  :root {
+    --ua-blue:        #0C234B;
+    --ua-blue-deep:   #07173a;
+    --ua-blue-mid:    #1b3870;
+    --ua-red:         #AB0520;
+    --ua-red-bright:  #c8102e;
+    --cream:          #f7f4ee;
+    --cream-warm:     #efe9dc;
+    --paper:          #fbfaf6;
+    --ink:            #161616;
+    --ink-soft:       #2a2a2a;
+    --mute:           #6b6b6b;
+    --rule:           #d8d2c4;
+    --code-bg:        #0f1623;
+    --code-fg:        #e6edf3;
+    --good:           #1f7a4d;
+    --warn:           #c87a00;
+
+    --pad-x:          110px;
+    --pad-top:        96px;
+    --pad-bottom:     90px;
+  }
+
+  html, body { margin: 0; padding: 0; background: #000; }
+  body { font-family: 'Manrope', system-ui, sans-serif; color: var(--ink); }
+
+  deck-stage section {
+    box-sizing: border-box;
+    overflow: hidden;
+    background: var(--cream);
+    color: var(--ink);
+    font-family: 'Manrope', system-ui, sans-serif;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  .slide {
+    padding: var(--pad-top) var(--pad-x) var(--pad-bottom);
+    height: 100%;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+  }
+  .slide-dark { background: var(--ua-blue); color: var(--cream); }
+  .slide-paper { background: var(--paper); }
+  .slide-red { background: var(--ua-red); color: var(--cream); }
+
+  .tag {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    font-weight: 500;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--ua-red);
+  }
+  .slide-dark .tag { color: var(--cream-warm); opacity: 0.85; }
+  .slide-red .tag { color: var(--cream); opacity: 0.85; }
+
+  .title {
+    font-size: 72px;
+    font-weight: 700;
+    line-height: 1.02;
+    letter-spacing: -0.02em;
+    margin: 0;
+    text-wrap: balance;
+  }
+  .display {
+    font-size: 140px;
+    font-weight: 800;
+    line-height: 0.95;
+    letter-spacing: -0.035em;
+    margin: 0;
+    text-wrap: balance;
+  }
+  .subtitle {
+    font-size: 44px;
+    font-weight: 500;
+    line-height: 1.18;
+    color: var(--ink-soft);
+    margin: 0;
+    text-wrap: pretty;
+  }
+  .slide-dark .subtitle, .slide-red .subtitle { color: var(--cream-warm); }
+  .body {
+    font-size: 30px;
+    font-weight: 400;
+    line-height: 1.42;
+    color: var(--ink-soft);
+    margin: 0;
+    text-wrap: pretty;
+  }
+  .slide-dark .body { color: var(--cream-warm); }
+  .small {
+    font-size: 24px;
+    color: var(--mute);
+    line-height: 1.4;
+  }
+  .slide-dark .small { color: rgba(247,244,238,0.65); }
+  .mono { font-family: 'JetBrains Mono', monospace; }
+
+  .deck-header {
+    position: absolute;
+    top: 38px;
+    left: var(--pad-x);
+    right: var(--pad-x);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--mute);
+  }
+  .slide-dark .deck-header,
+  .slide-red .deck-header { color: rgba(247,244,238,0.55); }
+  .deck-header .lockup { display: flex; align-items: center; gap: 14px; }
+  .deck-header .ua-block {
+    display: inline-block;
+    width: 38px; height: 38px;
+    background: var(--ua-red);
+    color: var(--cream);
+    font-family: 'Manrope', sans-serif;
+    font-weight: 800;
+    font-size: 28px;
+    line-height: 38px;
+    text-align: center;
+    letter-spacing: -0.04em;
+  }
+  .slide-red .deck-header .ua-block { background: var(--cream); color: var(--ua-red); }
+
+  .deck-footer {
+    position: absolute;
+    bottom: 38px;
+    left: var(--pad-x);
+    right: var(--pad-x);
+    display: flex;
+    justify-content: space-between;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--mute);
+  }
+  .slide-dark .deck-footer,
+  .slide-red .deck-footer { color: rgba(247,244,238,0.5); }
+
+  .cols-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 80px; flex: 1; }
+  .cols-2-uneven { display: grid; grid-template-columns: 1.2fr 1fr; gap: 80px; flex: 1; }
+  .cols-3 { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 36px; flex: 1; }
+  .cols-4 { display: grid; grid-template-columns: 1fr 1fr 1fr 1fr; gap: 24px; }
+
+  .card {
+    background: var(--paper);
+    border: 1px solid var(--rule);
+    padding: 34px 36px;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+  }
+  .slide-dark .card {
+    background: rgba(255,255,255,0.04);
+    border-color: rgba(247,244,238,0.18);
+    color: var(--cream);
+  }
+  .card h4 {
+    font-size: 32px;
+    font-weight: 700;
+    margin: 0;
+    letter-spacing: -0.01em;
+    line-height: 1.05;
+  }
+  .card p {
+    font-size: 24px;
+    line-height: 1.4;
+    color: var(--ink-soft);
+    margin: 0;
+  }
+  .slide-dark .card p { color: var(--cream-warm); }
+  .card .kicker {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--ua-red);
+  }
+
+  pre.code {
+    background: var(--code-bg);
+    color: var(--code-fg);
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    line-height: 1.5;
+    padding: 36px 42px;
+    margin: 0;
+    border-radius: 4px;
+    overflow: hidden;
+    white-space: pre-wrap;
+  }
+  pre.code .c { color: #8b96a8; }
+  pre.code .k { color: #ffb86c; }
+  pre.code .s { color: #a6e22e; }
+  pre.code .v { color: #79c0ff; }
+  pre.code .x { color: #ff7b72; }
+  pre.code .y { color: #d2a8ff; }
+
+  .placeholder {
+    background:
+      repeating-linear-gradient(135deg,
+        rgba(12,35,75,0.06) 0,
+        rgba(12,35,75,0.06) 14px,
+        rgba(12,35,75,0.10) 14px,
+        rgba(12,35,75,0.10) 28px);
+    border: 1px solid var(--rule);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--ink-soft);
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    text-align: center;
+    padding: 24px;
+    box-sizing: border-box;
+  }
+
+  .section-slide {
+    padding: var(--pad-top) var(--pad-x) var(--pad-bottom);
+    height: 100%;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    position: relative;
+  }
+  .section-slide .part-num {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 28px;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    opacity: 0.7;
+    margin-bottom: 36px;
+  }
+  .section-slide .section-title {
+    font-size: 160px;
+    font-weight: 800;
+    line-height: 0.92;
+    letter-spacing: -0.035em;
+    margin: 0;
+    text-wrap: balance;
+  }
+  .section-slide .section-sub {
+    font-size: 36px;
+    font-weight: 400;
+    line-height: 1.3;
+    max-width: 1100px;
+    margin-top: 36px;
+    opacity: 0.85;
+  }
+
+  .title-slide {
+    height: 100%;
+    box-sizing: border-box;
+    padding: var(--pad-top) var(--pad-x) var(--pad-bottom);
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    position: relative;
+  }
+  .title-slide .grid-bg {
+    position: absolute; inset: 0;
+    background-image:
+      linear-gradient(rgba(247,244,238,0.05) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(247,244,238,0.05) 1px, transparent 1px);
+    background-size: 80px 80px;
+    pointer-events: none;
+  }
+  .title-slide-content {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 60px;
+  }
+
+  .step-label {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--ua-red);
+    margin-bottom: 18px;
+  }
+
+  table.surfaces {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 26px;
+  }
+  table.surfaces th, table.surfaces td {
+    text-align: left;
+    padding: 18px 16px;
+    border-bottom: 1px solid var(--rule);
+    vertical-align: top;
+  }
+  table.surfaces th {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--mute);
+    font-weight: 500;
+    border-bottom: 2px solid var(--ink);
+  }
+  table.surfaces td.tool {
+    font-weight: 700;
+    color: var(--ink);
+    font-size: 26px;
+  }
+  table.surfaces td.kind {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    color: var(--ua-red);
+    letter-spacing: 0.04em;
+  }
+  table.surfaces td.desc { color: var(--ink-soft); font-size: 24px; line-height: 1.35; }
+
+  .stack { display: flex; flex-direction: column; gap: 0; }
+  .stack-row {
+    display: grid;
+    grid-template-columns: 280px 1fr;
+    gap: 40px;
+    padding: 24px 0;
+    border-bottom: 1px solid var(--rule);
+    align-items: baseline;
+  }
+  .stack-row:last-child { border-bottom: none; }
+  .stack-row .label {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    color: var(--ua-red);
+  }
+  .stack-row .val {
+    font-size: 28px;
+    color: var(--ink-soft);
+    line-height: 1.35;
+  }
+  .stack-row .val strong { color: var(--ink); font-weight: 700; }
+
+  /* Capability blocks */
+  .cap-block {
+    border: 1px solid var(--rule);
+    background: var(--paper);
+    padding: 32px 32px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    min-height: 280px;
+  }
+  .cap-block .icon-letter {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 48px;
+    font-weight: 700;
+    color: var(--ua-red);
+    letter-spacing: -0.02em;
+  }
+  .cap-block h5 {
+    font-size: 28px;
+    font-weight: 700;
+    margin: 0;
+    line-height: 1.1;
+  }
+  .cap-block p {
+    font-size: 24px;
+    line-height: 1.4;
+    color: var(--ink-soft);
+    margin: 0;
+  }
+
+  /* Arrow flow for agentic loop */
+  .loop-flow {
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    align-items: center;
+    gap: 14px;
+  }
+  .loop-node {
+    background: var(--paper);
+    border: 1px solid var(--rule);
+    padding: 22px 18px;
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    min-height: 140px;
+    justify-content: center;
+  }
+  .loop-node.hi {
+    background: var(--ua-blue);
+    border-color: var(--ua-blue);
+    color: var(--cream);
+  }
+  .loop-node .num {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    color: var(--ua-red);
+    letter-spacing: 0.16em;
+  }
+  .loop-node.hi .num { color: var(--cream-warm); }
+  .loop-node .label {
+    font-size: 24px;
+    font-weight: 700;
+    line-height: 1.15;
+  }
+  .loop-arrow {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 36px;
+    color: var(--ua-red);
+    text-align: center;
+    font-weight: 700;
+  }
+
+  /* Quote callout */
+  .pullquote {
+    font-size: 44px;
+    line-height: 1.25;
+    font-weight: 500;
+    letter-spacing: -0.01em;
+    color: var(--ink);
+    text-wrap: pretty;
+  }
+  .slide-dark .pullquote { color: var(--cream); }
+  .pullquote::before {
+    content: "\201C";
+    font-family: 'Manrope', sans-serif;
+    font-size: 100px;
+    line-height: 0.5;
+    color: var(--ua-red);
+    vertical-align: -22px;
+    margin-right: 12px;
+  }
+  .attrib {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--mute);
+    margin-top: 32px;
+  }
+  .slide-dark .attrib { color: rgba(247,244,238,0.6); }
+
+  /* MCP diagram */
+  .mcp-diagram {
+    display: grid;
+    grid-template-columns: 1fr auto 1.6fr;
+    gap: 32px;
+    align-items: stretch;
+  }
+  .mcp-host, .mcp-server-stack {
+    border: 1px solid var(--rule);
+    background: var(--paper);
+    padding: 28px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+  .mcp-host { background: var(--ua-blue); color: var(--cream); border-color: var(--ua-blue); }
+  .mcp-host h5 { color: var(--cream); margin: 0; font-size: 26px; }
+  .mcp-host p { color: var(--cream-warm); margin: 0; font-size: 24px; line-height: 1.35; }
+  .mcp-host .kicker { color: var(--cream-warm); }
+  .mcp-server-stack { gap: 14px; }
+  .mcp-server {
+    border: 1px solid var(--rule);
+    padding: 16px 20px;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    background: var(--cream);
+  }
+  .mcp-server .name { color: var(--ink); font-weight: 700; }
+  .mcp-server .kind { color: var(--ua-red); font-size: 24px; letter-spacing: 0.08em; }
+  .mcp-bus {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+  }
+  .mcp-bus .line {
+    width: 60px;
+    height: 2px;
+    background: var(--ua-red);
+  }
+  .mcp-bus .label {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    color: var(--ua-red);
+    letter-spacing: 0.16em;
+    transform: rotate(90deg);
+    transform-origin: center;
+    white-space: nowrap;
+    margin-top: 40px;
+    margin-bottom: 40px;
+  }
+  .kicker {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--ua-red);
+  }
+
+  /* Sandbox tier columns */
+  .tier-card {
+    background: var(--paper);
+    border: 1px solid var(--rule);
+    border-top: 6px solid var(--ua-red);
+    padding: 32px 32px 36px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+  .tier-card .level {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    color: var(--ua-red);
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+  }
+  .tier-card h4 {
+    font-size: 36px;
+    font-weight: 700;
+    margin: 0;
+    line-height: 1.1;
+    letter-spacing: -0.01em;
+  }
+  .tier-card p { font-size: 24px; line-height: 1.4; margin: 0; color: var(--ink-soft); }
+  .tier-card ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .tier-card ul li {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    color: var(--ink-soft);
+    padding-left: 18px;
+    position: relative;
+    line-height: 1.4;
+  }
+  .tier-card ul li::before {
+    content: "›";
+    position: absolute;
+    left: 0;
+    color: var(--ua-red);
+    font-weight: 700;
+  }
+
+  /* Safety stack rows */
+  .safety-row {
+    display: grid;
+    grid-template-columns: 60px 1fr 2.2fr;
+    gap: 36px;
+    padding: 22px 0;
+    border-bottom: 1px solid var(--rule);
+    align-items: baseline;
+  }
+  .safety-row:last-child { border-bottom: none; }
+  .safety-row .n {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    color: var(--ua-red);
+    letter-spacing: 0.06em;
+  }
+  .safety-row .h {
+    font-size: 30px;
+    font-weight: 700;
+    color: var(--ink);
+    letter-spacing: -0.01em;
+    line-height: 1.15;
+  }
+  .safety-row .d {
+    font-size: 24px;
+    color: var(--ink-soft);
+    line-height: 1.4;
+  }
+
+  /* Inline warning band */
+  .warn-band {
+    background: var(--ua-red);
+    color: var(--cream);
+    padding: 28px 36px;
+    display: flex;
+    gap: 28px;
+    align-items: center;
+  }
+  .warn-band .label {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 24px;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    flex: 0 0 auto;
+    border-right: 1px solid rgba(247,244,238,0.4);
+    padding-right: 28px;
+  }
+  .warn-band .msg { font-size: 26px; line-height: 1.35; }
+</style>
+</head>
+<body>
+
+<deck-stage width="1920" height="1080">
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       1 · TITLE
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="01 Title" class="slide-dark">
+    <div class="title-slide">
+      <div class="grid-bg"></div>
+      <div class="deck-header">
+        <div class="lockup">
+          <span class="ua-block">A</span>
+          <span>University of Arizona · BIO5 Institute</span>
+        </div>
+        <div>PH&amp;AI Summer School · 2nd Edition</div>
+      </div>
+
+      <div class="title-slide-content" style="margin-top: 40px;">
+        <div class="tag" style="font-size: 26px;">AI Fluency Track · Deep Dive</div>
+        <h1 class="display" style="font-size: 156px;">
+          Agentic<br>Engineering<span style="color: var(--ua-red-bright);">.</span>
+        </h1>
+        <p class="body" style="color: var(--cream-warm); font-size: 36px; max-width: 1200px;">
+          Past the chat window — into your filesystem, your shell, and your research stack.
+          Vibe coding · MCP · sandboxes · safety.
+        </p>
+      </div>
+
+      <div class="title-slide-content" style="gap: 12px;">
+        <div style="background: rgba(247,244,238,0.4); height: 1px; max-width: 600px;"></div>
+        <div style="display: flex; justify-content: space-between; align-items: flex-end;">
+          <div>
+            <div style="color: var(--cream); font-weight: 600; font-size: 36px;">Tyson Swetnam, PhD</div>
+            <div class="small mono" style="margin-top: 6px;">Associate Professor · BIO5 Institute</div>
+          </div>
+          <div class="mono small" style="text-align: right;">
+            Grand Challenges Research Building<br>
+            Tucson, AZ · June 2026
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       2 · THE MENTAL SHIFT
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="02 Mental Shift">
+    <div class="slide">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>02 / The Shift</div>
+      </div>
+
+      <div class="tag" style="margin-top: 40px;">What's Different This Time</div>
+      <h2 class="title" style="margin-top: 20px; max-width: 1600px;">The model isn't reading your prompt. It's reading your filesystem.</h2>
+
+      <div class="cols-2" style="margin-top: 80px; gap: 60px;">
+        <div class="card" style="border-left: 6px solid var(--mute);">
+          <div class="kicker" style="color: var(--mute);">Yesterday · the basics deck</div>
+          <h4>Prompt → response.</h4>
+          <p>A chat window. One turn at a time. The model sees what you paste. You see what it writes. The boundary between "your computer" and "the AI" is a textbox.</p>
+        </div>
+        <div class="card" style="border-left: 6px solid var(--ua-red);">
+          <div class="kicker">Today · this deck</div>
+          <h4>Prompt → tool calls → effects.</h4>
+          <p>The model reads your repo, edits files, runs your tests, calls APIs, queries databases — through standardized tool protocols. You approve actions, not paragraphs.</p>
+        </div>
+      </div>
+
+      <p class="body" style="margin-top: 60px; max-width: 1600px; font-size: 28px;">
+        Everything in the basics deck still applies — CRAFT, role, format. But the failure modes
+        change: an unclear prompt no longer wastes a turn. It wastes a <span style="font-weight: 700; color: var(--ink);">file</span>.
+      </p>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>02 · THE SHIFT</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       3 · WHAT YOU'LL LEAVE WITH
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="03 Outcome" class="slide-paper">
+    <div class="slide slide-paper">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>03 / Outcome</div>
+      </div>
+
+      <div class="tag" style="margin-top: 40px;">What You'll Leave With</div>
+      <h2 class="title" style="margin-top: 20px; max-width: 1600px;">Four lenses for the agentic stack.</h2>
+
+      <div class="cols-4" style="margin-top: 80px; gap: 28px;">
+        <div class="cap-block">
+          <span class="icon-letter">01.</span>
+          <h5>Vibe coding.</h5>
+          <p>The IDE / extension / CLI / browser landscape. How to choose a surface for the work.</p>
+        </div>
+        <div class="cap-block">
+          <span class="icon-letter">02.</span>
+          <h5>Local filesystems.</h5>
+          <p>What an agent on your machine can actually do — and how to scope its authority.</p>
+        </div>
+        <div class="cap-block">
+          <span class="icon-letter">03.</span>
+          <h5>MCP.</h5>
+          <p>The Model Context Protocol — USB-C for AI. Standard plug for tools, data, resources.</p>
+        </div>
+        <div class="cap-block">
+          <span class="icon-letter">04.</span>
+          <h5>Sandboxes.</h5>
+          <p>Containers, VMs, hosted notebooks. Where you let the agent run hot without setting the lab on fire.</p>
+        </div>
+      </div>
+
+      <p class="small" style="margin-top: 70px; max-width: 1500px;">
+        Companion page: <span class="mono" style="color: var(--ua-red); font-size: 24px;">tyson-swetnam.github.io/intro-gpt/vibe/</span> and
+        <span class="mono" style="color: var(--ua-red); font-size: 24px;">/research/</span>. Every section below has a deeper write-up there.
+      </p>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>03 · OUTCOME</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       4 · PART 1 · VIBE CODING
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="04 Part 1 Divider" class="slide-dark">
+    <div class="section-slide">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>Part 01 · Vibe Coding</div>
+      </div>
+      <div>
+        <div class="part-num">Part 01</div>
+        <h2 class="section-title">Vibe<br>coding.</h2>
+        <p class="section-sub">
+          An LLM, your IDE, your repo. The fastest way to ship code you don't fully understand —
+          and the fastest way to break something you do.
+        </p>
+      </div>
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>04 · PART 01</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       5 · KARPATHY QUOTE — WHAT VIBE CODING IS
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="05 Karpathy" class="slide-paper">
+    <div class="slide slide-paper">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>05 / Origin</div>
+      </div>
+
+      <div class="tag" style="margin-top: 40px;">February 2025 · Karpathy on X</div>
+      <h2 class="title" style="margin-top: 20px; max-width: 1600px;">Where the term came from — and what it actually means.</h2>
+
+      <div class="cols-2-uneven" style="margin-top: 80px; gap: 80px; flex: 0 1 auto;">
+        <div style="display: flex; flex-direction: column; justify-content: center;">
+          <p class="pullquote">
+            There's a new kind of coding I call <strong style="color: var(--ua-red);">vibe coding</strong>, where you fully give in to the vibes, embrace exponentials, and forget that the code even exists.
+          </p>
+          <div class="attrib">Andrej Karpathy · Feb 2 2025</div>
+        </div>
+        <div style="display: flex; flex-direction: column; gap: 22px; justify-content: center;">
+          <div class="card">
+            <div class="kicker">Working definition</div>
+            <p style="font-size: 26px;">Using an LLM to generate and edit code directly inside your IDE — the model is a collaborative partner, not a search engine you copy-paste from.</p>
+          </div>
+          <div class="card" style="border-left: 6px solid var(--ua-red);">
+            <div class="kicker">The trade</div>
+            <p style="font-size: 26px;">Speed in exchange for meaningful authority over your machine. Files, network, shell. Worth knowing what you handed over.</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>05 · ORIGIN</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       6 · THE FOUR SURFACES
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="06 Four Surfaces">
+    <div class="slide">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>06 / Surfaces</div>
+      </div>
+
+      <div class="tag" style="margin-top: 40px;">Pick The Surface That Matches The Job</div>
+      <h2 class="title" style="margin-top: 20px; max-width: 1600px;">Four families. Different authority, different blast radius.</h2>
+
+      <div class="cols-4" style="margin-top: 56px; gap: 24px;">
+        <div class="tier-card">
+          <div class="level">01 · Desktop IDE</div>
+          <h4>Standalone editors.</h4>
+          <p>Full-fat editing experience. Agent sees the open repo.</p>
+          <ul>
+            <li>Claude Desktop</li>
+            <li>VS Code</li>
+            <li>Cursor</li>
+            <li>Positron (Posit)</li>
+            <li>Windsurf</li>
+            <li>Antigravity</li>
+          </ul>
+        </div>
+        <div class="tier-card">
+          <div class="level">02 · VS Code ext</div>
+          <h4>Inside your editor.</h4>
+          <p>Bring the agent to where you already work. BYOM in some cases.</p>
+          <ul>
+            <li>Claude Code</li>
+            <li>Gemini CLI Companion</li>
+            <li>OpenAI Codex</li>
+            <li>GitHub Copilot</li>
+            <li>Cline</li>
+            <li>Roo Code</li>
+          </ul>
+        </div>
+        <div class="tier-card">
+          <div class="level">03 · CLI</div>
+          <h4>Terminal-first.</h4>
+          <p>Scriptable, headless, scriptable into pipelines and CI.</p>
+          <ul>
+            <li>Aider</li>
+            <li>Claude Code CLI</li>
+            <li>OpenAI Codex CLI</li>
+            <li>Gemini CLI</li>
+            <li>OpenCode.ai</li>
+          </ul>
+        </div>
+        <div class="tier-card">
+          <div class="level">04 · Browser</div>
+          <h4>Sandboxed by default.</h4>
+          <p>No local filesystem. Code runs in a hosted Python or Node env.</p>
+          <ul>
+            <li>Claude Code (web)</li>
+            <li>ChatGPT</li>
+            <li>Google Gemini</li>
+            <li>OpenWebUI (self-host)</li>
+          </ul>
+        </div>
+      </div>
+
+      <p class="small" style="margin-top: 36px; max-width: 1500px; font-size: 24px;">
+        Authority increases left-to-right in your head, but is actually highest in <em>01 · Desktop IDE</em>:
+        that's the surface that touches your real files.
+      </p>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>06 · SURFACES</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       7 · CHOOSING A TOOL — DECISION TABLE
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="07 Tool Decision" class="slide-paper">
+    <div class="slide slide-paper">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>07 / Choosing</div>
+      </div>
+
+      <div class="tag" style="margin-top: 40px;">A First-Pass Decision Table</div>
+      <h2 class="title" style="margin-top: 20px; max-width: 1600px;">Match the surface to the situation. Try one. Switch when it stops fitting.</h2>
+
+      <table class="surfaces" style="margin-top: 56px;">
+        <thead>
+          <tr>
+            <th>If you are…</th>
+            <th>Surface</th>
+            <th>Reach for</th>
+            <th>Notes</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td class="desc">New to vibe coding, exploring</td>
+            <td class="kind">Browser</td>
+            <td class="tool">ChatGPT / Gemini / Claude.ai</td>
+            <td class="desc">No install, sandboxed Python, zero blast radius.</td>
+          </tr>
+          <tr>
+            <td class="desc">A researcher with R / Python notebooks</td>
+            <td class="kind">Desktop IDE</td>
+            <td class="tool">Positron · Cursor · VS Code</td>
+            <td class="desc">Native data-science tooling, agent has repo context.</td>
+          </tr>
+          <tr>
+            <td class="desc">Comfortable in terminal, scripting workflows</td>
+            <td class="kind">CLI</td>
+            <td class="tool">Claude Code CLI · Aider · Gemini CLI</td>
+            <td class="desc">Pipe into CI, run headless against many repos.</td>
+          </tr>
+          <tr>
+            <td class="desc">Working with sensitive data on your laptop</td>
+            <td class="kind">BYOM</td>
+            <td class="tool">Cline + Ollama · Aider + local LLM</td>
+            <td class="desc">Self-hosted model; nothing leaves the machine.</td>
+          </tr>
+          <tr>
+            <td class="desc">Already deep in GitHub PR review</td>
+            <td class="kind">VS Code ext</td>
+            <td class="tool">GitHub Copilot · Claude Code</td>
+            <td class="desc">Lives in the editor you already have open.</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <p class="small" style="margin-top: 24px; max-width: 1500px; font-size: 24px;">
+        None of these are permanent. The cost of switching is one afternoon of muscle memory.
+      </p>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>07 · CHOOSING</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       8 · PART 2 · LOCAL FILESYSTEMS
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="08 Part 2 Divider" class="slide-red">
+    <div class="section-slide">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>Part 02 · Local Filesystems</div>
+      </div>
+      <div>
+        <div class="part-num">Part 02</div>
+        <h2 class="section-title">Your<br>filesystem<br>is a tool.</h2>
+        <p class="section-sub">
+          Once you grant filesystem access, the agent has everything your user does.
+          That's the deal. Understand what it can reach.
+        </p>
+      </div>
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>08 · PART 02</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       9 · WHAT AN AGENT CAN DO
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="09 Agent Capabilities">
+    <div class="slide">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>09 / Capabilities</div>
+      </div>
+
+      <div class="tag" style="margin-top: 40px;">What An Agent On Your Machine Can Actually Do</div>
+      <h2 class="title" style="margin-top: 20px; max-width: 1600px;">Four authorities. Granted with one click. Worth saying out loud.</h2>
+
+      <div class="cols-4" style="margin-top: 70px; gap: 24px;">
+        <div class="cap-block">
+          <span class="icon-letter">FS.</span>
+          <h5>Filesystem.</h5>
+          <p>Read, modify, and delete files anywhere your user has permission. Not just the open repo — your home directory, your Downloads, your Dropbox.</p>
+        </div>
+        <div class="cap-block">
+          <span class="icon-letter">NET.</span>
+          <h5>Network.</h5>
+          <p>Make API calls, fetch URLs, exfiltrate data, install packages. The agent has your IP and your connectivity.</p>
+        </div>
+        <div class="cap-block">
+          <span class="icon-letter">SH.</span>
+          <h5>Shell.</h5>
+          <p>Execute arbitrary commands — file deletion, force pushes, cloud sync. The terminal is the terminal.</p>
+        </div>
+        <div class="cap-block">
+          <span class="icon-letter">ENV.</span>
+          <h5>Environment.</h5>
+          <p>Read environment variables — including secrets your shell exposes. API keys, database URLs, auth tokens.</p>
+        </div>
+      </div>
+
+      <div class="warn-band" style="margin-top: 70px;">
+        <div class="label">Heads-up</div>
+        <div class="msg">LLMs occasionally hallucinate package names. Attackers register them on PyPI / npm. If your agent installs dependencies without review, it can pull in malicious code. Read the <span class="mono">requirements.txt</span> diff.</div>
+      </div>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>09 · CAPABILITIES</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       10 · PRACTICES THAT KEEP IT MANAGEABLE
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="10 Practices" class="slide-paper">
+    <div class="slide slide-paper">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>10 / Practices</div>
+      </div>
+
+      <div class="tag" style="margin-top: 40px;">Practices That Keep This Manageable</div>
+      <h2 class="title" style="margin-top: 20px; max-width: 1600px;">Seven habits. Adopt them before you point an agent at code that matters.</h2>
+
+      <div class="stack" style="margin-top: 56px;">
+        <div class="stack-row">
+          <div class="label">01 · Review</div>
+          <div class="val">Read every command before approving. Most tools prompt — <strong>don't auto-approve everything.</strong></div>
+        </div>
+        <div class="stack-row">
+          <div class="label">02 · Scope</div>
+          <div class="val">Work inside project-specific virtual environments, not at user-root.</div>
+        </div>
+        <div class="stack-row">
+          <div class="label">03 · Secrets</div>
+          <div class="val">Never store secrets in code. Use environment variables and secret managers.</div>
+        </div>
+        <div class="stack-row">
+          <div class="label">04 · Sudo</div>
+          <div class="val">Be cautious with <span class="mono" style="font-size: 26px;">sudo</span> or administrator privileges. Agents rarely need them.</div>
+        </div>
+        <div class="stack-row">
+          <div class="label">05 · Monitor</div>
+          <div class="val">Actively watch agent actions when you're learning a new tool. Trust comes from observation.</div>
+        </div>
+        <div class="stack-row">
+          <div class="label">06 · Policy</div>
+          <div class="val">Follow your institution's security and privacy policies. UA has classifications. So does your IRB.</div>
+        </div>
+        <div class="stack-row">
+          <div class="label">07 · Sandbox</div>
+          <div class="val">For sensitive work, use containers or VMs — covered in Part 04.</div>
+        </div>
+      </div>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>10 · PRACTICES</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       11 · PART 3 · MCP
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="11 Part 3 Divider" class="slide-dark">
+    <div class="section-slide">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>Part 03 · Model Context Protocol</div>
+      </div>
+      <div>
+        <div class="part-num">Part 03 · MCP</div>
+        <h2 class="section-title">USB-C<br>for AI.</h2>
+        <p class="section-sub">
+          One protocol, any tool. The plug that lets the same agent talk to your filesystem,
+          your database, your calendar, your lab instruments.
+        </p>
+      </div>
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>11 · PART 03</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       12 · MCP CONCEPT
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="12 MCP Concept">
+    <div class="slide">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>12 / MCP · What</div>
+      </div>
+
+      <div class="tag" style="margin-top: 40px;">Model Context Protocol</div>
+      <h2 class="title" style="margin-top: 20px; max-width: 1600px;">An open protocol that standardizes how applications provide context to LLMs.</h2>
+
+      <div class="cols-2-uneven" style="margin-top: 70px; gap: 80px; flex: 0 1 auto;">
+        <div style="display: flex; flex-direction: column; justify-content: center; gap: 28px;">
+          <p class="body" style="font-size: 32px; color: var(--ink-soft);">
+            Before MCP: every agent shipped its own plugin system. Connecting Claude to your filesystem
+            meant one integration; connecting Cursor to the same filesystem meant another.
+          </p>
+          <p class="body" style="font-size: 32px; color: var(--ink);">
+            After MCP: write one server. Any compatible client can use it.
+            <strong>The "M×N" problem becomes "M + N".</strong>
+          </p>
+          <div class="card" style="border-left: 6px solid var(--ua-red);">
+            <div class="kicker">Maintained by</div>
+            <p style="font-size: 26px;">Anthropic, open spec at <span class="mono" style="font-size: 24px; color: var(--ua-red);">modelcontextprotocol.io</span>. Implementations from Anthropic, OpenAI, community.</p>
+          </div>
+        </div>
+        <div style="display: flex; flex-direction: column; gap: 18px; justify-content: center;">
+          <div class="card">
+            <div class="kicker">Tools</div>
+            <p style="font-size: 24px;">Functions the model can call — read a file, run a query, send an email.</p>
+          </div>
+          <div class="card">
+            <div class="kicker">Resources</div>
+            <p style="font-size: 24px;">Data the model can pull in — files, database rows, API responses.</p>
+          </div>
+          <div class="card">
+            <div class="kicker">Prompts</div>
+            <p style="font-size: 24px;">Reusable templates the server publishes for the client to surface.</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>12 · MCP</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       13 · MCP ARCHITECTURE
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="13 MCP Architecture" class="slide-paper">
+    <div class="slide slide-paper">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>13 / MCP · How</div>
+      </div>
+
+      <div class="tag" style="margin-top: 32px;">Anatomy Of An MCP Connection</div>
+      <h2 class="title" style="margin-top: 14px; max-width: 1600px; font-size: 60px;">One host. One protocol. Many servers, each scoped to one job.</h2>
+
+      <div class="mcp-diagram" style="margin-top: 44px;">
+        <div class="mcp-host">
+          <div class="kicker">Host / Client</div>
+          <h5>Claude Desktop</h5>
+          <p style="margin-top: 6px;">The app the user talks to. Manages the model, the chat, and the list of attached servers.</p>
+          <div style="flex: 1;"></div>
+          <p style="font-family: 'JetBrains Mono', monospace; font-size: 24px; color: var(--cream-warm);">also: Cursor · VS Code · Cline · Claude Code</p>
+        </div>
+
+        <div class="mcp-bus">
+          <div class="label">MCP · JSON-RPC over stdio / SSE</div>
+        </div>
+
+        <div class="mcp-server-stack">
+          <div class="kicker">Servers · each a separate process</div>
+          <div class="mcp-server">
+            <span class="name">filesystem</span>
+            <span class="kind">read · write · list</span>
+          </div>
+          <div class="mcp-server">
+            <span class="name">github</span>
+            <span class="kind">issues · prs</span>
+          </div>
+          <div class="mcp-server">
+            <span class="name">postgres</span>
+            <span class="kind">query · schema</span>
+          </div>
+          <div class="mcp-server">
+            <span class="name">slack</span>
+            <span class="kind">channels · messages</span>
+          </div>
+          <div class="mcp-server">
+            <span class="name">your-own-thing</span>
+            <span class="kind">lab gear · REDCap</span>
+          </div>
+        </div>
+      </div>
+
+      <p class="small" style="margin-top: 36px; max-width: 1500px; font-size: 24px;">
+        Each server is its own process with its own permissions. You enable them one at a time
+        in the host's config — and you revoke them the same way.
+      </p>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>13 · MCP · ARCH</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       14 · MCP CONFIG EXAMPLE
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="14 MCP Config">
+    <div class="slide">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>14 / MCP · Config</div>
+      </div>
+
+      <div class="tag" style="margin-top: 36px;">From Zero To Connected</div>
+      <h2 class="title" style="margin-top: 16px; max-width: 1600px; font-size: 60px;">Connecting Claude Desktop to your project folder — the actual JSON.</h2>
+
+      <div class="cols-2-uneven" style="margin-top: 36px; gap: 48px; flex: 0 1 auto;">
+        <pre class="code" style="font-size: 24px; line-height: 1.4; padding: 24px 30px;"><span class="c">// claude_desktop_config.json</span>
+{
+  <span class="y">"mcpServers"</span>: {
+    <span class="y">"filesystem"</span>: {
+      <span class="y">"command"</span>: <span class="s">"npx"</span>,
+      <span class="y">"args"</span>: [
+        <span class="s">"-y"</span>,
+        <span class="s">"@modelcontextprotocol/server-filesystem"</span>,
+        <span class="s">"/Users/tswetnam/research/phai-2026"</span>
+      ]
+    },
+    <span class="y">"postgres"</span>: {
+      <span class="y">"command"</span>: <span class="s">"npx"</span>,
+      <span class="y">"args"</span>: [<span class="s">"-y"</span>, <span class="s">"@mcp/server-postgres"</span>],
+      <span class="y">"env"</span>: { <span class="y">"DATABASE_URL"</span>: <span class="s">"..."</span> }
+    }
+  }
+}</pre>
+        <div style="display: flex; flex-direction: column; gap: 22px; justify-content: center;">
+          <div class="card">
+            <div class="kicker">What this buys you</div>
+            <p style="font-size: 24px;">Claude can now read &amp; write files in your project folder and query your local Postgres — through tool calls you approve in the chat.</p>
+          </div>
+          <div class="card" style="border-left: 6px solid var(--ua-red);">
+            <div class="kicker">Scoping rule</div>
+            <p style="font-size: 24px;">The path you pass in is the leash — the filesystem server cannot reach outside it. Use this. Point each MCP at the narrowest scope that does the job.</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>14 · MCP · CONFIG</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       15 · PART 4 · AI SANDBOXES
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="15 Part 4 Divider" class="slide-dark">
+    <div class="section-slide">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>Part 04 · AI Sandboxes</div>
+      </div>
+      <div>
+        <div class="part-num">Part 04</div>
+        <h2 class="section-title">Let it<br>run hot.</h2>
+        <p class="section-sub">
+          The point of a sandbox: somewhere the agent can experiment, install random packages,
+          and break things without taking your laptop down with it.
+        </p>
+      </div>
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>15 · PART 04</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       16 · THREE SANDBOX TIERS
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="16 Sandbox Tiers">
+    <div class="slide">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>16 / Sandboxes</div>
+      </div>
+
+      <div class="tag" style="margin-top: 40px;">Three Tiers Of Isolation</div>
+      <h2 class="title" style="margin-top: 20px; max-width: 1600px;">Pick the tier that matches the data sensitivity, not your comfort.</h2>
+
+      <div class="cols-3" style="margin-top: 70px; gap: 32px;">
+        <div class="tier-card">
+          <div class="level">Tier 01 · Soft</div>
+          <h4>Hosted notebook.</h4>
+          <p>ChatGPT's Python sandbox, Gemini code execution, Claude artifacts. The agent runs code in someone else's container.</p>
+          <ul>
+            <li>Zero install</li>
+            <li>No local file access</li>
+            <li>Ephemeral by default</li>
+            <li>Data leaves your machine</li>
+          </ul>
+        </div>
+        <div class="tier-card" style="border-top-color: var(--ua-blue);">
+          <div class="level" style="color: var(--ua-blue);">Tier 02 · Medium</div>
+          <h4>Container / devcontainer.</h4>
+          <p>Docker or VS Code devcontainer. Agent runs against your real repo but inside an isolated FS + network.</p>
+          <ul>
+            <li>Reproducible env</li>
+            <li>Limited host access</li>
+            <li>Survives destructive commands</li>
+            <li>Network still escapes</li>
+          </ul>
+        </div>
+        <div class="tier-card" style="border-top-color: var(--ink);">
+          <div class="level" style="color: var(--ink);">Tier 03 · Hard</div>
+          <h4>VM / data enclave.</h4>
+          <p>Full virtual machine or institutional enclave. For HIPAA, FERPA, CUI, or anything where leakage is unacceptable.</p>
+          <ul>
+            <li>Strong isolation</li>
+            <li>Auditable</li>
+            <li>Often offline</li>
+            <li>Heavy to spin up</li>
+          </ul>
+        </div>
+      </div>
+
+      <p class="small" style="margin-top: 60px; max-width: 1500px;">
+        Public health work crosses all three tiers in a week. Synthetic data → soft. Cohort exploration → medium.
+        Patient-level analysis → hard. Match the tier to the row.
+      </p>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>16 · SANDBOXES</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       17 · THE AGENTIC LOOP
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="17 Agentic Loop" class="slide-paper">
+    <div class="slide slide-paper">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>17 / The Loop</div>
+      </div>
+
+      <div class="tag" style="margin-top: 36px;">The Agentic Loop</div>
+      <h2 class="title" style="margin-top: 16px; max-width: 1600px; font-size: 60px;">Plan → act → observe → revise. The model that does this in a container is the one you trust.</h2>
+
+      <div style="display: grid; grid-template-columns: repeat(9, auto); align-items: center; justify-content: center; gap: 12px; margin-top: 60px;">
+        <div class="loop-node" style="min-height: 110px; min-width: 150px;">
+          <div class="num">01</div>
+          <div class="label">Goal</div>
+        </div>
+        <div class="loop-arrow" style="font-size: 30px;">→</div>
+        <div class="loop-node" style="min-height: 110px; min-width: 150px;">
+          <div class="num">02</div>
+          <div class="label">Plan</div>
+        </div>
+        <div class="loop-arrow" style="font-size: 30px;">→</div>
+        <div class="loop-node hi" style="min-height: 110px; min-width: 180px;">
+          <div class="num">03</div>
+          <div class="label">Act · tool call</div>
+        </div>
+        <div class="loop-arrow" style="font-size: 30px;">→</div>
+        <div class="loop-node" style="min-height: 110px; min-width: 150px;">
+          <div class="num">04</div>
+          <div class="label">Observe</div>
+        </div>
+        <div class="loop-arrow" style="font-size: 30px;">↻</div>
+        <div class="loop-node" style="min-height: 110px; min-width: 180px;">
+          <div class="num">05</div>
+          <div class="label">Revise &amp; loop</div>
+        </div>
+      </div>
+
+      <div class="cols-2" style="margin-top: 56px; flex: 0 1 auto; gap: 60px;">
+        <div class="card" style="padding: 26px 30px;">
+          <div class="kicker">Where humans belong</div>
+          <p style="font-size: 24px;">At <strong>step 03 approval</strong> for high-stakes actions, and at <strong>step 04 observation</strong> for everything. Don't auto-approve write tools.</p>
+        </div>
+        <div class="card" style="padding: 26px 30px;">
+          <div class="kicker">Why the sandbox matters</div>
+          <p style="font-size: 24px;">Steps 03→04 may run 50 iterations before surfacing to you. Each iteration touches the FS. A bad plan in a sandbox is a wasted minute; on your laptop it's a restore.</p>
+        </div>
+      </div>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>17 · LOOP</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       18 · PART 5 · AGENTIC RESEARCH
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="18 Part 5 Divider" class="slide-red">
+    <div class="section-slide">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>Part 05 · Agentic Research</div>
+      </div>
+      <div>
+        <div class="part-num">Part 05</div>
+        <h2 class="section-title">Putting it<br>to work.</h2>
+        <p class="section-sub">
+          Literature review · hypothesis generation · code &amp; data analysis. The same stack,
+          pointed at a real research problem.
+        </p>
+      </div>
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>18 · PART 05</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       19 · LIT REVIEW STACK
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="19 Lit Review">
+    <div class="slide">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>19 / Literature</div>
+      </div>
+
+      <div class="tag" style="margin-top: 40px;">Literature Review &amp; Synthesis</div>
+      <h2 class="title" style="margin-top: 20px; max-width: 1600px;">Four tools. Four jobs. Don't reach for the same one twice.</h2>
+
+      <div class="cols-4" style="margin-top: 70px; gap: 24px;">
+        <div class="cap-block">
+          <span class="icon-letter">P.</span>
+          <h5>Perplexity</h5>
+          <p style="font-family: 'JetBrains Mono', monospace; font-size: 24px; color: var(--ua-red);">Search &amp; summarize</p>
+          <p>The "what's out there on X?" tool. Web-first, citations inline, fast.</p>
+        </div>
+        <div class="cap-block">
+          <span class="icon-letter">G.</span>
+          <h5>Gemini Deep Research</h5>
+          <p style="font-family: 'JetBrains Mono', monospace; font-size: 24px; color: var(--ua-red);">Multi-step report</p>
+          <p>You pose a research question, it produces a structured report over many minutes.</p>
+        </div>
+        <div class="cap-block">
+          <span class="icon-letter">N.</span>
+          <h5>NotebookLM</h5>
+          <p style="font-family: 'JetBrains Mono', monospace; font-size: 24px; color: var(--ua-red);">Your own corpus</p>
+          <p>Upload your PDFs / docs / audio. Grounded answers, no hallucinated citations.</p>
+        </div>
+        <div class="cap-block">
+          <span class="icon-letter">S.</span>
+          <h5>ScholarAI / SemScholar</h5>
+          <p style="font-family: 'JetBrains Mono', monospace; font-size: 24px; color: var(--ua-red);">Peer-reviewed</p>
+          <p>Custom GPTs and tools pinned to academic indexes. For when "web" isn't enough.</p>
+        </div>
+      </div>
+
+      <p class="small" style="margin-top: 70px; max-width: 1500px;">
+        Rule of thumb: <strong style="color: var(--ink);">Perplexity</strong> for scoping,
+        <strong style="color: var(--ink);">ScholarAI</strong> for citations you'll actually cite,
+        <strong style="color: var(--ink);">NotebookLM</strong> for synthesizing what you've already collected.
+      </p>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>19 · LITERATURE</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       20 · HYPOTHESIS + ROLE
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="20 Hypothesis Roles" class="slide-paper">
+    <div class="slide slide-paper">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>20 / Hypothesis</div>
+      </div>
+
+      <div class="tag" style="margin-top: 40px;">Hypothesis Generation Via Role-Play</div>
+      <h2 class="title" style="margin-top: 20px; max-width: 1600px;">Roles aren't just style. They route which patterns the model surfaces.</h2>
+
+      <div class="cols-2" style="margin-top: 60px; gap: 60px; flex: 0 1 auto;">
+        <div style="display: flex; flex-direction: column; gap: 22px;">
+          <div class="step-label">Pattern 01 · Domain expert</div>
+          <pre class="code" style="font-size: 24px; line-height: 1.4;">I want you to act as a data scientist
+with complete knowledge of R, the
+TidyVerse, and RStudio.
+
+Write the code to:
+1. Create a new R project env
+2. Load Palmer Penguins
+3. Plot regressions of body mass,
+   bill length &amp; width by species
+
+Output as R + RMarkdown with text
+and code in ``` blocks.</pre>
+        </div>
+        <div style="display: flex; flex-direction: column; gap: 22px;">
+          <div class="step-label">Pattern 02 · Talk to a dead scientist</div>
+          <pre class="code" style="font-size: 24px; line-height: 1.4;">I want you to respond as though
+you are the mathematician
+Benoit Mandelbrot.
+
+Explain the relationship of
+lacunarity and fractal dimension
+for a self-affine series.
+
+Show results using mathematical
+equations in LaTeX or MathJax.</pre>
+          <p class="small" style="font-size: 24px;">Try with and without web search enabled. The deltas tell you which claims the model is generating vs. retrieving.</p>
+        </div>
+      </div>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>20 · HYPOTHESIS</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       21 · CODE EXECUTION SURFACES
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="21 Code Execution">
+    <div class="slide">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>21 / Code Execution</div>
+      </div>
+
+      <div class="tag" style="margin-top: 40px;">Where The Code Actually Runs</div>
+      <h2 class="title" style="margin-top: 20px; max-width: 1600px;">Same prompt. Five very different places it could execute.</h2>
+
+      <table class="surfaces" style="margin-top: 56px;">
+        <thead>
+          <tr>
+            <th>Surface</th>
+            <th>Where it runs</th>
+            <th>Sees your files?</th>
+            <th>Good for</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td class="tool">ChatGPT Python tool</td>
+            <td class="desc">OpenAI sandbox</td>
+            <td class="kind">No</td>
+            <td class="desc">Quick plots, data wrangling, "show me what this CSV looks like"</td>
+          </tr>
+          <tr>
+            <td class="tool">Gemini code execution</td>
+            <td class="desc">Google sandbox</td>
+            <td class="kind">No</td>
+            <td class="desc">Inline Python results in chat, large-context analysis</td>
+          </tr>
+          <tr>
+            <td class="tool">Claude Code (CLI / IDE)</td>
+            <td class="desc">Your machine</td>
+            <td class="kind">Yes — via MCP</td>
+            <td class="desc">Real repo work, multi-file refactors, test runs</td>
+          </tr>
+          <tr>
+            <td class="tool">Jupyter AI</td>
+            <td class="desc">Your kernel</td>
+            <td class="kind">Yes</td>
+            <td class="desc">Notebook-native AI in JupyterLab; great for R / Python research</td>
+          </tr>
+          <tr>
+            <td class="tool">Cline + Ollama</td>
+            <td class="desc">Your machine, local model</td>
+            <td class="kind">Yes</td>
+            <td class="desc">Sensitive code; nothing leaves the laptop</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <p class="small" style="margin-top: 50px; max-width: 1500px;">
+        Match the row to the data classification. Synthetic test data → row 1. De-identified cohort → row 3.
+        IRB-sensitive → row 5, or push to an institutional enclave.
+      </p>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>21 · EXECUTION</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       22 · SAFETY STACK
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="22 Safety Stack" class="slide-paper">
+    <div class="slide slide-paper">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>22 / Safety</div>
+      </div>
+
+      <div class="tag" style="margin-top: 28px;">Coding Safely With AI</div>
+      <h2 class="title" style="margin-top: 10px; max-width: 1600px; font-size: 52px;">Six categories. Work through them in order before pointing an agent at code that matters.</h2>
+
+      <div class="stack" style="margin-top: 28px;">
+        <div class="safety-row" style="padding: 14px 0;">
+          <div class="n">01</div>
+          <div class="h" style="font-size: 26px;">Review every line.</div>
+          <div class="d" style="font-size: 24px; line-height: 1.3;">Correctness, efficiency, maintainability. Test edge cases. Check for SQL injection, XSS, weak auth, secret leakage. If you don't understand a block, ask the AI to explain it.</div>
+        </div>
+        <div class="safety-row" style="padding: 14px 0;">
+          <div class="n">02</div>
+          <div class="h" style="font-size: 26px;">Local execution risks.</div>
+          <div class="d" style="font-size: 24px; line-height: 1.3;">FS, network, shell, env vars. Review commands before approving. Project-scoped venvs. Never store secrets in code. Avoid admin privileges.</div>
+        </div>
+        <div class="safety-row" style="padding: 14px 0;">
+          <div class="n">03</div>
+          <div class="h" style="font-size: 26px;">Bias, licensing, IP.</div>
+          <div class="d" style="font-size: 24px; line-height: 1.3;">Models reproduce non-inclusive identifiers, deprecated patterns, licensed code. AI-generated code is "common practice," not "best practice." Check license compatibility. Document AI use.</div>
+        </div>
+        <div class="safety-row" style="padding: 14px 0;">
+          <div class="n">04</div>
+          <div class="h" style="font-size: 26px;">Privacy &amp; data handling.</div>
+          <div class="d" style="font-size: 24px; line-height: 1.3;">Prompts, file contents, terminal output, project metadata — all leave your machine. Don't share PHI/PII in prompts. For sensitive code: Cline+Ollama, Aider+local LLM.</div>
+        </div>
+        <div class="safety-row" style="padding: 14px 0;">
+          <div class="n">05</div>
+          <div class="h" style="font-size: 26px;">Accessibility.</div>
+          <div class="d" style="font-size: 24px; line-height: 1.3;">Ask for WCAG review on UI code. Alt text, ARIA, color contrast, keyboard nav. Audit identifiers and comments for inclusive language.</div>
+        </div>
+        <div class="safety-row" style="padding: 14px 0;">
+          <div class="n">06</div>
+          <div class="h" style="font-size: 26px;">Environmental footprint.</div>
+          <div class="d" style="font-size: 24px; line-height: 1.3;">Don't use a frontier model when a smaller one will do. Cache results. Avoid agentic loops that fire speculative requests. Cumulative compute is the cost.</div>
+        </div>
+      </div>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>22 · SAFETY</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       23 · RESOURCES
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="23 Resources">
+    <div class="slide">
+      <div class="deck-header">
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div>23 / Resources</div>
+      </div>
+
+      <div class="tag" style="margin-top: 40px;">Bookmarks</div>
+      <h2 class="title" style="margin-top: 20px; max-width: 1600px;">Where to keep reading after the room empties out.</h2>
+
+      <div class="stack" style="margin-top: 60px;">
+        <div class="stack-row">
+          <div class="label">Vibe Coding</div>
+          <div class="val mono" style="color: var(--ua-red); font-size: 26px;">tyson-swetnam.github.io/intro-gpt/vibe/</div>
+        </div>
+        <div class="stack-row">
+          <div class="label">Research</div>
+          <div class="val mono" style="color: var(--ua-red); font-size: 26px;">tyson-swetnam.github.io/intro-gpt/research/</div>
+        </div>
+        <div class="stack-row">
+          <div class="label">Agentic AI</div>
+          <div class="val mono" style="color: var(--ua-red); font-size: 26px;">tyson-swetnam.github.io/intro-gpt/agentic/</div>
+        </div>
+        <div class="stack-row">
+          <div class="label">MCP</div>
+          <div class="val mono" style="color: var(--ua-red); font-size: 26px;">modelcontextprotocol.io  ·  /intro-gpt/mcp/</div>
+        </div>
+        <div class="stack-row">
+          <div class="label">Sandboxes</div>
+          <div class="val mono" style="color: var(--ua-red); font-size: 26px;">tyson-swetnam.github.io/intro-gpt/ai_sandboxes/</div>
+        </div>
+        <div class="stack-row">
+          <div class="label">Local models</div>
+          <div class="val mono" style="color: var(--ua-red); font-size: 26px;">ollama.com  ·  /intro-gpt/ollama/</div>
+        </div>
+        <div class="stack-row">
+          <div class="label">Claude Code</div>
+          <div class="val mono" style="color: var(--ua-red); font-size: 26px;">docs.anthropic.com/en/docs/claude-code</div>
+        </div>
+      </div>
+
+      <div class="deck-footer">
+        <div>UA PH&amp;AI 2026</div>
+        <div>23 · RESOURCES</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════════════════════════════════
+       24 · Q&A
+       ════════════════════════════════════════════════════════════════════ -->
+  <section data-screen-label="24 Thank You" class="slide-dark">
+    <div class="slide slide-dark">
+      <div class="title-slide">
+        <div class="grid-bg"></div>
+        <div class="deck-header">
+          <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+          <div>End · Q&amp;A</div>
+        </div>
+
+        <div class="title-slide-content" style="margin-top: 0;">
+          <div class="tag" style="color: var(--cream-warm);">Now point one at something.</div>
+          <h2 class="display" style="font-size: 184px;">
+            Boot a<br>sandbox<span style="color: var(--ua-red-bright);">.</span>
+          </h2>
+          <p class="body" style="max-width: 1200px; font-size: 34px;">
+            Pick a real task from this week. Spin up a devcontainer. Attach one MCP.
+            Watch the agent loop. Approve every write. Decide what to delegate next.
+          </p>
+        </div>
+
+        <div class="title-slide-content" style="gap: 12px;">
+          <div style="background: rgba(247,244,238,0.4); height: 1px; max-width: 600px;"></div>
+          <div style="display: flex; justify-content: space-between; align-items: flex-end;">
+            <div>
+              <div style="color: var(--cream); font-weight: 600; font-size: 36px;">Tyson Swetnam, PhD</div>
+              <div class="small mono" style="margin-top: 6px;">tswetnam@arizona.edu · @tswetnam</div>
+            </div>
+            <div class="mono small" style="text-align: right;">
+              BIO5 Institute<br>
+              University of Arizona
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+</deck-stage>
+
+</body>
+</html>

--- a/zensical.toml
+++ b/zensical.toml
@@ -123,6 +123,7 @@ Ethics = [
 [[project.nav]]
 Tutorials = [
     { "Claude Code Workflow" = "claude-code.md" },
+    { "Presentations" = "tutorials/presentations/index.md" },
     { "Public Health" = "tutorials/publichealth/casestudy.md" },
     { "Map making" = "tutorials/publichealth/gis.md" }
 ]


### PR DESCRIPTION
## Summary

New **Presentations** tab under **Tutorials**, containing four UA PH&AI Summer School slide decks the user uploaded plus a minimal deck shell to run them.

## What's in the PR

**`docs/tutorials/presentations/index.md`** — landing page with how-to-view instructions (keyboard nav, click nav, persistence, print-to-PDF) and a list of the four decks with brief summaries and cross-links to the docs lessons each pairs with.

**`docs/tutorials/presentations/deck-stage.js`** — minimal custom-element shell (`<deck-stage>`) that all four HTML decks reference. ~170 lines, vanilla JS, no dependencies. Handles:

- Canvas scaling (1920×1080 → viewport, preserves aspect ratio)
- Keyboard nav: arrows, PgUp/Dn, Home/End, space, Enter, Backspace, `f` for fullscreen
- Click-nav: right half advances, left half goes back
- Slide-counter overlay (bottom-right)
- Persistence: URL hash (`#7`) + `localStorage` per-deck path
- Print-to-PDF: one slide per page at design dimensions
- `postMessage({slideIndexChanged: N})` to `window.parent` for speaker-notes windows

**Four HTML decks** (copied as-is, renamed to hyphen-case slugs):

| Slug | Pairs with |
|------|-----------|
| `prompt-engineering-basics.html` (24 slides) | [Prompt Engineering](https://github.com/tyson-swetnam/intro-gpt/blob/main/docs/prompts.md) |
| `prompt-engineering-deep-dive.html` (agentic workflows) | Prompt Engineering, [Vibe Coding](https://github.com/tyson-swetnam/intro-gpt/blob/main/docs/vibe.md), [Agentic AI](https://github.com/tyson-swetnam/intro-gpt/blob/main/docs/agentic.md) |
| `ethics-and-environmental-impact.html` (panel) | [Ethics of AI](https://github.com/tyson-swetnam/intro-gpt/blob/main/docs/ethics.md), [Bias](https://github.com/tyson-swetnam/intro-gpt/blob/main/docs/bias.md), [Legal](https://github.com/tyson-swetnam/intro-gpt/blob/main/docs/legal.md) |
| `geospatial-ai-public-health.html` (GIS lab) | [Public Health Map](https://github.com/tyson-swetnam/intro-gpt/blob/main/docs/tutorials/publichealth/gis.md) |

**`zensical.toml`** — adds `Presentations` as the second item in the Tutorials nav block, between `Claude Code Workflow` and the public-health labs.

## Test plan

- [ ] `Publish docs via GitHub` workflow completes successfully on merge
- [ ] `/tutorials/presentations/` renders the landing page with all four deck links
- [ ] Each deck opens at its slug URL and the `<deck-stage>` shell scales the 1920×1080 canvas to fit the browser
- [ ] Arrow-key, space, Page-Up/Down, Home/End navigation all work
- [ ] Slide counter shows `N / total` at bottom-right
- [ ] URL hash updates as you advance (`#1` → `#2` → ...) and reloading the URL with a hash lands on the right slide
- [ ] Print preview shows one slide per page at design dimensions
- [ ] Tutorials nav shows the new Presentations entry

## Notes

- `deck-stage.js` is a minimal implementation. The user's authoring environment may have a fuller version (speaker notes, overview mode, etc.) — feel free to swap in a richer one without breaking the four decks, since they only depend on the `<deck-stage>` custom-element + `<section>` children contract.
- HTML decks were copied as-is from the uploads — no edits to their slide content.

https://claude.ai/code/session_016V7qR3rPU4vy5ogRPhib8X

---
_Generated by [Claude Code](https://claude.ai/code/session_016V7qR3rPU4vy5ogRPhib8X)_