### PR TITLE
Fix Presentations nav + add no-rail to decks for fullscreen view

### DIFF
--- a/docs/tutorials/presentations/ethics-and-environmental-impact.html
+++ b/docs/tutorials/presentations/ethics-and-environmental-impact.html
@@ -829,7 +829,7 @@
   </svg>
 </template>
 
-<deck-stage width="1920" height="1080">
+<deck-stage no-rail width="1920" height="1080">
 
   <!-- ════════════════════════════════════════════════════════════════════
        1 · TITLE

--- a/docs/tutorials/presentations/geospatial-ai-public-health.html
+++ b/docs/tutorials/presentations/geospatial-ai-public-health.html
@@ -427,7 +427,7 @@
 </head>
 <body>
 
-<deck-stage width="1920" height="1080">
+<deck-stage no-rail width="1920" height="1080">
 
   <!-- ════════════════════════════════════════════════════════════════════
        1 · TITLE SLIDE

--- a/docs/tutorials/presentations/overview.md
+++ b/docs/tutorials/presentations/overview.md
@@ -5,10 +5,24 @@ A small library of HTML slide decks authored for the [UA Public Health & AI Summ
 ## How to view
 
 - Click a deck title below to open it. Use your browser's "open in new tab" if you want the slides visible alongside the docs.
-- **Keyboard:** Arrow keys, space, Page Up / Page Down to navigate. `Home` / `End` jump to start or end. `f` toggles full-screen.
+- **Keyboard navigation:** Arrow keys, space, Page Up / Page Down move between slides. `Home` / `End` jump to start or end. `R` restarts at slide 1. Number keys `1`–`9` jump directly to that slide.
 - **Click navigation:** click the right half of the slide to advance, left half to go back.
 - Each deck remembers your last position via `localStorage` and the URL hash (e.g. `#7` for slide 7) — refresh-safe.
-- **Print to PDF:** your browser's print dialog produces a 1920×1080 PDF with one slide per page.
+
+### Fullscreen presentation
+
+Each deck is configured with the `no-rail` attribute, so the thumbnail rail does **not** appear by default — you get the slide canvas alone, scaled to fit your browser window. For a truly fullscreen presentation (the workshop default):
+
+1. Open the deck.
+2. Press your browser's fullscreen shortcut — **F11** on Windows / Linux, **Cmd + Ctrl + F** on macOS Chrome / Edge / Firefox, or use the browser menu (View → Enter Full Screen).
+3. Navigate with the keyboard shortcuts above.
+4. Press the same shortcut (or `Esc`) to exit fullscreen.
+
+If you *do* want the thumbnail rail (for previewing all slides while you author or edit), remove the `no-rail` attribute from the `<deck-stage>` tag at the top of the HTML file.
+
+### Print to PDF
+
+Use your browser's print dialog. The decks ship with a `@media print` stylesheet that lays out every slide as its own page at the design size (1920×1080), so File → Print → "Save as PDF" produces a clean one-page-per-slide PDF with no extra configuration.
 
 ## Decks
 
@@ -38,7 +52,7 @@ Lab deck for the GIS practical: building an interactive story-map of a public-he
 
 ## About the deck shell
 
-These decks use a small custom element, `<deck-stage>`, served alongside the HTML at [`deck-stage.js`](deck-stage.js). It handles canvas scaling, keyboard and click navigation, the slide counter, URL-hash persistence, and print-to-PDF. The full source is short and editable — fork it freely.
+These decks use a small custom element, `<deck-stage>`, served alongside the HTML at [`deck-stage.js`](deck-stage.js). It handles canvas scaling, keyboard and click navigation, the slide-count overlay, the thumbnail rail (suppressed here via `no-rail`), URL-hash persistence, speaker-notes postMessage, and the print-to-PDF stylesheet.
 
 ## License
 

--- a/docs/tutorials/presentations/prompt-engineering-basics.html
+++ b/docs/tutorials/presentations/prompt-engineering-basics.html
@@ -468,7 +468,7 @@
 </head>
 <body>
 
-<deck-stage width="1920" height="1080">
+<deck-stage no-rail width="1920" height="1080">
 
   <!-- ════════════════════════════════════════════════════════════════════
        1 · TITLE SLIDE

--- a/docs/tutorials/presentations/prompt-engineering-deep-dive.html
+++ b/docs/tutorials/presentations/prompt-engineering-deep-dive.html
@@ -625,7 +625,7 @@
 </head>
 <body>
 
-<deck-stage width="1920" height="1080">
+<deck-stage no-rail width="1920" height="1080">
 
   <!-- ════════════════════════════════════════════════════════════════════
        1 · TITLE

--- a/zensical.toml
+++ b/zensical.toml
@@ -124,7 +124,7 @@ Ethics = [
 Tutorials = [
     { "Claude Code Workflow" = "claude-code.md" },
     { "KEYS Internship (BIO5)" = "tutorials/keys.md" },
-    { "Presentations" = "tutorials/presentations/index.md" },
+    { "Presentations" = "tutorials/presentations/overview.md" },
     { "Public Health" = "tutorials/publichealth/casestudy.md" },
     { "Map making" = "tutorials/publichealth/gis.md" }
 ]


### PR DESCRIPTION
## Summary

Two fixes in one PR.

### 1. Presentations nav entry was rendering as a blank gap

Material's `navigation.indexes` feature treats any `index.md` inside a directory as that directory's "section index" — clickable on the parent section header, not as a separate leaf item. Since "Presentations" was a leaf in Tutorials (not a section with sub-items), the leaf was suppressed and a blank slot appeared between "KEYS Internship (BIO5)" and "Public Health".

**Fix:** Rename `docs/tutorials/presentations/index.md` → `docs/tutorials/presentations/overview.md` so it's treated as a regular page, not a section index. Update `zensical.toml` to point at `overview.md`.

**URL change:** `/tutorials/presentations/` → `/tutorials/presentations/overview/`. The four HTML decks remain at `/tutorials/presentations/*.html` (unchanged), and the in-page links to them resolve correctly.

### 2. Hide the thumbnail rail by default for fullscreen viewing

You asked how to view the decks fullscreen without the left-side slide rail. Per the comment block at the top of `deck-stage.js`, the rail can be suppressed via the `no-rail` attribute on the `<deck-stage>` element.

**Fix:** Add `no-rail` to all four HTML decks. Anyone who *does* want the rail back (for previewing while authoring) can remove the attribute.

For true browser-fullscreen on top of that, use **F11** (Windows / Linux) or **Cmd + Ctrl + F** (macOS) — documented in the new "Fullscreen presentation" section of overview.md.

### 3. Drive-by: correct stale doc claims in overview.md

My previous draft claimed `f` toggles fullscreen, which my home-rolled `deck-stage.js` stub supported but your real implementation does not. Removed that claim and documented the actual key handlers: arrows / PgUp/Dn / space, Home/End, R for restart, 1-9 for jump-to-slide.

## Files changed

- `docs/tutorials/presentations/index.md` → renamed to `overview.md` (with content updated)
- `docs/tutorials/presentations/{prompt-engineering-basics,prompt-engineering-deep-dive,ethics-and-environmental-impact,geospatial-ai-public-health}.html` — `<deck-stage>` → `<deck-stage no-rail>` (one-line change each)
- `zensical.toml` — nav path updated

## Test plan

- [ ] Build workflow completes on merge
- [ ] Tutorials sidebar shows "Presentations" between "KEYS Internship (BIO5)" and "Public Health"
- [ ] `/tutorials/presentations/overview/` renders the page
- [ ] Opening any of the four `*.html` decks shows the slide canvas without the left-side thumbnail rail
- [ ] F11 puts the browser in fullscreen mode; navigation and click-nav still work
- [ ] Removing `no-rail` from a deck (locally) brings the rail back

https://claude.ai/code/session_016V7qR3rPU4vy5ogRPhib8X

---
_Generated by [Claude Code](https://claude.ai/code/session_016V7qR3rPU4vy5ogRPhib8X)_