### PR TITLE
Consolidate AI-rights / Magnifica Humanitas content from ethics.md into legal.md

### DIFF
--- a/docs/ethics.md
+++ b/docs/ethics.md
@@ -21,98 +21,12 @@ Over the next 70 years, Artificial Intelligence persisted mainly in [the minds o
 
 As consumers of GPTs and other AI platforms, we must consider in what ways can we use AI both effectively, and ethically.
 
-## AI Constitutions and Bills of Rights
+## AI Constitutions, Bills of Rights, and Pope Leo XIV's encyclical
 
-How should the values that guide AI systems be set, and by whom? Two distinct approaches have emerged: **corporate AI constitutions** written by AI companies for their own models (Anthropic's *Claude Constitution* is the canonical example), and **public AI bills of rights** developed through democratic processes (the White House *Blueprint for an AI Bill of Rights*, October 2022, is the leading example).
+The deeper treatment of foundational governance documents for AI — corporate "AI constitutions" like Anthropic's *Claude Constitution*; the public *Blueprint for an AI Bill of Rights*; sociologist Alondra Nelson's "civic grammar" framework, T. H. Marshall's social-citizenship argument, and the three-imperatives framework from Nelson's *Daedalus* essay; and Pope Leo XIV's May 2026 encyclical *Magnifica Humanitas* — has been consolidated into the [Ethical & Legal Considerations](legal.md) lesson, where the U.S. Executive Orders, international agreements, and congressional context already live. Two anchors:
 
-Sociologist [Alondra Nelson](https://www.ias.edu/sss/faculty/nelson){target=_blank} — who led the Blueprint's development as acting director of the White House Office of Science and Technology Policy (OSTP) — argues in [*A civic grammar for AI rights*](https://www.science.org/doi/10.1126/science.aeh7153){target=_blank} (Science, 2026) that these two forms of foundational document do very different work, and that one of them is structurally insufficient as a source of democratic legitimacy.
-
-### Corporate constitutions vs. public bills of rights
-
-- **Corporate AI constitutions** are internal training and alignment specifications. They describe a company's vision of how its model should behave. They are not negotiated with the publics affected by the model's deployment, and they can be revised by company fiat. Nelson notes that newer revisions of Anthropic's Claude Constitution have quietly removed references to international human rights agreements — and with them protections for "personal liberty, freedom of religion and intellectual property," and other rights that earlier versions included. Historian Jill Lepore observed that the document arrived *"at a trying time for both artificial intelligence and constitutional democracy."*
-- **Public AI bills of rights** declare rights claims that publics can extend to new institutions and new harms. Their force comes from democratic legitimacy and the broader legal-political infrastructure, not from the model developers. The Blueprint took its name from the first ten amendments to the U.S. Constitution but, Nelson argues, structurally resembles a different founding document — the **Declaration of Independence**. It declares principles and claims rights against concentrated power, but it does not establish courts, enforcement mechanisms, or procedures for redress.
-
-### "Civic grammar" and the diffusion of rights claims
-
-Nelson describes what has emerged as a **"civic grammar"**: a shared vocabulary of rights claims (non-discrimination, transparency, data privacy, notice, human alternatives) that publics can extend to new institutions and new harms, and that "has been traveling across jurisdictions, partisan lines, and institutional contexts." The American tradition is long — Patients' Bill of Rights, Consumer Bill of Rights, Tenants' Bill of Rights, Workers' Bill of Rights, Taxpayers' Bill of Rights — and the AI Bill of Rights template has spread the same way: actors with no shared political coalition, sometimes with explicit antipathy toward each other, adopting a common vocabulary because each, separately, has encountered the same kind of algorithmic harm.
-
-This pattern reflects what sociologists David Strang and John Meyer call **institutional diffusion** among *weakly related actors* — a conceptual rather than relational mechanism by which abstract typologies become "a strategy for making sense of the world." Connecticut Democrats, Oklahoma Republicans, Florida's Republican governor, and a national student-advocacy network can adopt the same vocabulary without coordinating, because all are responding to the same structural condition: AI reshaping people's lives without their consultation. (For the specific state-level examples and the international convergence, see [Blueprint for an AI Bill of Rights](legal.md#blueprint-for-an-ai-bill-of-rights) in the Legal lesson.)
-
-### Marshall's social citizenship and the AI rights tier
-
-Nelson grounds the analysis in British sociologist T. H. Marshall's 1950 essay *Citizenship and Social Class*. Marshall argued that rights expand historically through successive waves of claim-making: civil rights extending to political rights, political rights extending to **social rights** — entitlements to economic security and the conditions of participation, against harms of industrial capitalism that individual civil-liberties frameworks could not address. Rights, in Marshall's account, "are never fully delivered at the moment of declaration. They are successively rearticulated by publics who attempt to hold institutions to commitments those institutions have not yet honored."
-
-The Blueprint's five principles, Nelson argues, map onto Marshall's social-rights tier. They are not classical civil liberties; they are entitlements against systems "that increasingly govern access to employment, credit, healthcare, housing, and education." The structural parallel — collective, diffuse, opaque harms that older rights frameworks address only partially — is what explains the cross-partisan convergence: "actors who disagree on nearly everything else agree that algorithmic power requires a social citizenship response."
-
-### The limits of rights talk
-
-Nelson is clear-eyed about what civic grammar cannot do on its own:
-
-- **Accommodation can mimic transformation.** A vocabulary that moves easily across partisan lines may have been "drained of the political content that gives rights claims their force."
-- **Rights individualize structural problems.** Frameworks built around individual claims often fail to address the collective and systemic nature of algorithmic harms.
-- **Declaration is not delivery.** History shows "declarations of entitlement and their substantive delivery can remain decades apart, separated by the organized power of those who benefit from the status quo."
-
-Nelson's clarifying question for democratic institutions: *will they take this civic grammar seriously before the AI companies finish writing their own constitutions for us all?*
-
-### Three imperatives for studying AI: question, object, tool
-
-Nelson's argument about AI rights builds on a broader claim she develops in [*Field Theory: AI as Social Science Question, Object & Tool*](https://www.amacad.org/publication/daedalus/field-theory-ai-social-science-question-object-tool){target=_blank} (*Daedalus*, Winter/Spring 2026): AI models, tools, and systems pose **three interrelated imperatives** for the social sciences.
-
-1. **AI as social-science question.** Renewed attention to social theories of how technology, human experience, and social order are entangled. Nelson reaches back to Weber's analysis of rationalization and W. E. B. Du Bois's study of technology and inequality, and forward to contemporary scholarship on algorithmic governance.
-2. **AI as object of inquiry.** AI systems themselves require study as social, political, and economic artifacts — not just engineering products. Their training corpora, their labor relations, their ideological commitments, and their effects on the institutions that deploy them all merit investigation in their own right.
-3. **AI as method/tool.** AI capabilities may transform — or upend — the practice of social investigation itself: large-scale text analysis, multimodal pattern detection, conversational interviewing at scale. That transformation deserves critical scrutiny rather than uncritical adoption.
-
-The capacities social science distinctively brings to all three, Nelson argues: **historicizing the apparently unprecedented**, **tracing connections across scales** (from individual experience to institutional behavior to political economy), and **centering those most affected** by technological change.
-
-This three-part framing also doubles as a useful diagnostic. When you read a piece of AI-ethics scholarship, ask which of the three imperatives it engages — that often clarifies what kind of argument is being made and what kind of counter-argument would land.
-
-!!! info "Sources and further reading"
-
-    - Alondra Nelson, [*A civic grammar for AI rights*](https://www.science.org/doi/10.1126/science.aeh7153){target=_blank}, *Science* (2026). DOI: 10.1126/science.aeh7153
-    - Alondra Nelson, [*Field Theory: AI as Social Science Question, Object & Tool*](https://www.amacad.org/publication/daedalus/field-theory-ai-social-science-question-object-tool){target=_blank}, *Daedalus* (Winter/Spring 2026)
-    - Alondra Nelson, [Bluesky thread on these principles](https://bsky.app/profile/alondra.bsky.social/post/3mltfqoc7ok2y){target=_blank}
-    - T. H. Marshall, "Citizenship and Social Class" (1950)
-    - [Blueprint for an AI Bill of Rights](https://bidenwhitehouse.archives.gov/ostp/ai-bill-of-rights/){target=_blank} (White House OSTP, October 2022, archived)
-    - Anthropic, [Claude's Constitution](https://www.anthropic.com/news/claudes-constitution){target=_blank}
-
-## Catholic social teaching: *Magnifica Humanitas* (Pope Leo XIV, 2026)
-
-On May 25, 2026, Pope Leo XIV released [*Magnifica Humanitas*](https://www.vatican.va/content/leo-xiv/en/encyclicals/documents/20260515-magnifica-humanitas.html){target=_blank} ("Magnificent Humanity"), his first encyclical, addressed to Catholics and "every person of goodwill." The 235-page document treats artificial intelligence as the central moral question of the age and frames AI as a new industrial revolution requiring a parallel foundational moral response.
-
-The signing date is deliberate: **May 15, 2026** is the **135th anniversary of Pope Leo XIII's *Rerum Novarum*** (1891), the foundational encyclical of modern Catholic social teaching, written to address the dignity of workers amid the 19th-century industrial revolution. Leo XIV explicitly places AI alongside that earlier disruption as a moment demanding renewed teaching.
-
-In a break with tradition, Pope Leo personally presented the encyclical at the Vatican alongside Chris Olah, co-founder of Anthropic — the first time a pontiff has presented an encyclical himself rather than delegating the task to cardinals.
-
-### Core teachings
-
-- **The centrality of the human person.** The dignity of the human person is affirmed as infinite. Human beings take precedence over AI, and any deployment of AI must be evaluated against that priority.
-- **Critique of *transhumanism*** — the project of using technology to overcome biological limits such as aging. Leo XIV rejects the framing of human finitude as a problem to be engineered away.
-- **Critique of *posthumanism*** — the philosophical position that blurs the boundaries between humans and machines, or denies the distinctiveness of human beings. The encyclical names this as an active "anti-human vision" embedded in contemporary AI development, not merely a speculative philosophical stance.
-- **Catholic social doctrine as the evaluation framework:** *dignity of the person*, *the common good*, and *justice* serve as the principles against which any AI deployment should be measured.
-- **Coverage** extends across education, the economy, unemployment, work, human trafficking, and war — the same broad social-impact terrain Catholic social teaching has historically addressed.
-
-### Calls to action
-
-- **"Disarm AI"** — withdraw AI from military applications and from purely economic interests; direct it to the common good.
-- **Stricter state and international regulation** of AI companies, not industry self-governance.
-- An explicit address to "every person of goodwill" extends the encyclical's claims of moral force beyond its Catholic audience — a move consistent with how *Laudato Si'* (2015, on climate) and the Vatican's *Antiqua et Nova* (January 2025, the Dicastery for the Doctrine of the Faith's earlier note on AI) sought ethical common ground beyond doctrinal lines.
-
-### Why this matters for the workshop
-
-For students and practitioners thinking about AI ethics, *Magnifica Humanitas* is significant in several ways:
-
-- It situates AI alongside the industrial revolution as a moment requiring **foundational moral and institutional response** rather than industry self-governance. That framing converges with the [civic grammar argument](#ai-constitutions-and-bills-of-rights) above — both Pope Leo and Alondra Nelson arrive at the same conclusion from very different starting points: *corporate self-governance is structurally insufficient as a source of legitimacy*.
-- It introduces a **theological and humanistic vocabulary** (transhumanism, posthumanism, infinite human dignity, the common good) that may not appear in technical AI-ethics literature but increasingly shapes public reception of AI.
-- The decision to present the encyclical alongside an AI-company executive signals that the Church views the conversation as dialogic rather than purely adversarial.
-
-!!! info "Sources and further reading"
-
-    - Pope Leo XIV, [*Magnifica Humanitas*](https://www.vatican.va/content/leo-xiv/en/encyclicals/documents/20260515-magnifica-humanitas.html){target=_blank} (signed May 15, 2026; published May 25, 2026)
-    - [Vatican News announcement](https://www.vaticannews.va/en/pope/news/2026-05/pope-leo-xiv-first-encyclical-magnifica-humanitas.html){target=_blank}
-    - [CNN: Pope Leo warns of AI fueling warfare in first major theological document](https://www.cnn.com/2026/05/25/europe/pope-leo-ai-encyclical-magnifica-humanitas-intl){target=_blank}
-    - [America Magazine: Pope Leo XIV calls for AI to be 'disarmed', directed to the common good](https://www.americamagazine.org/speeches/2026/05/25/pope-leo-xiv-calls-for-ai-to-be-disarmed-directed-to-the-common-good/){target=_blank}
-    - Earlier related Catholic texts: *Antiqua et Nova* (Dicastery for the Doctrine of the Faith, January 2025, on AI); Pope Francis, [*Laudato Si'*](https://www.vatican.va/content/francesco/en/encyclicals/documents/papa-francesco_20150524_enciclica-laudato-si.html){target=_blank} (2015, on care for creation)
-    - Pope Leo XIII, [*Rerum Novarum*](https://www.vatican.va/content/leo-xiii/en/encyclicals/documents/hf_l-xiii_enc_15051891_rerum-novarum.html){target=_blank} (1891) — the 135-year predecessor referenced by the signing date
+- [Blueprint for an AI Bill of Rights](legal.md#blueprint-for-an-ai-bill-of-rights) — the policy timeline; Nelson's "civic grammar"; the cross-partisan diffusion of state-level AI bills (Connecticut, Oklahoma, Florida, the Student AI Bill of Rights); T. H. Marshall's social-citizenship framework; the three imperatives for studying AI; international convergence; the limits of rights talk; and the gap between declaration and enforcement.
+- [Catholic social teaching: *Magnifica Humanitas*](legal.md#catholic-social-teaching-magnifica-humanitas-pope-leo-xiv-2026) — Pope Leo XIV's first encyclical and its convergence with the civic-grammar critique of corporate self-governance.
 
 ## [:material-scale-balance: Ethical and Legal Considerations](legal.md)
 

--- a/docs/legal.md
+++ b/docs/legal.md
@@ -122,9 +122,13 @@ In response to the rapid rise of generative AI, specifically GPTs, new agreement
 
 ## Blueprint for an AI Bill of Rights
 
+How should the values that guide AI systems be set, and by whom? Two distinct answers have emerged: **corporate AI constitutions** written by AI companies for their own models (Anthropic's *Claude Constitution* is the canonical example), and **public AI bills of rights** developed through democratic processes (the White House *Blueprint for an AI Bill of Rights*, October 2022, is the leading example). Sociologist [Alondra Nelson](https://www.ias.edu/sss/faculty/nelson){target=_blank} — who led the Blueprint's development as acting director of the White House Office of Science and Technology Policy (OSTP) — argues in [*A civic grammar for AI rights*](https://www.science.org/doi/10.1126/science.aeh7153){target=_blank} (Science, 2026) that these two forms of foundational document do very different work, and that one of them is structurally insufficient as a source of democratic legitimacy.
+
+A third category emerged in May 2026 with Pope Leo XIV's first encyclical [*Magnifica Humanitas*](#catholic-social-teaching-magnifica-humanitas-pope-leo-xiv-2026): a transnational moral institution speaking on behalf of 1.4 billion Catholics, claiming authority against both the technocratic paradigm and the states that abdicate the field. The encyclical is treated in its own section below.
+
 ### Timeline and status
 
-The [**Blueprint for an AI Bill of Rights**](https://bidenwhitehouse.archives.gov/ostp/ai-bill-of-rights/){target=_blank} emerged from a public process announced in an October 2021 *Wired* essay by the White House Office of Science and Technology Policy (OSTP). It was released in October 2022 with **five principles** to guide the design, development, and deployment of automated systems:
+The [**Blueprint for an AI Bill of Rights**](https://bidenwhitehouse.archives.gov/ostp/ai-bill-of-rights/){target=_blank} emerged from a public process announced in an October 2021 *Wired* essay by the White House OSTP. It was released in October 2022 with **five principles** to guide the design, development, and deployment of automated systems:
 
 1. **Safe and Effective Systems** — protection from unsafe or ineffective systems.
 2. **Algorithmic Discrimination Protections** — equitable design and use of automated systems.
@@ -134,19 +138,26 @@ The [**Blueprint for an AI Bill of Rights**](https://bidenwhitehouse.archives.go
 
 These principles were incorporated into President Biden's [October 2023 Executive Order on Safe, Secure, and Trustworthy AI](https://www.federalregister.gov/documents/2023/11/01/2023-24283/safe-secure-and-trustworthy-development-and-use-of-artificial-intelligence){target=_blank}. The Executive Order was rescinded by President Trump's January 2025 [Removing Barriers to American Leadership in Artificial Intelligence](https://www.whitehouse.gov/presidential-actions/2025/01/removing-barriers-to-american-leadership-in-artificial-intelligence/){target=_blank}. The Blueprint itself was always non-binding guidance.
 
+### Corporate constitutions vs. public bills of rights
+
+- **Corporate AI constitutions** are internal training and alignment specifications. They describe a company's vision of how its model should behave. They are not negotiated with the publics affected by the model's deployment, and they can be revised by company fiat. Nelson notes that newer revisions of Anthropic's *Claude Constitution* have quietly removed references to international human rights agreements — and with them protections for "personal liberty, freedom of religion and intellectual property" that earlier versions included. Historian Jill Lepore observed that the document arrived *"at a trying time for both artificial intelligence and constitutional democracy."*
+- **Public AI bills of rights** declare rights claims that publics can extend to new institutions and new harms. Their force comes from democratic legitimacy and the broader legal-political infrastructure, not from the model developers.
+
+The deeper question, Nelson asks, is *who gets to author the foundational documents that govern AI* — companies, or publics?
+
 ### Constitution vs. Bill of Rights vs. Declaration of Independence
 
-Sociologist [Alondra Nelson](https://www.ias.edu/sss/faculty/nelson){target=_blank} — who led the Blueprint's development as acting director of OSTP — argues in [*A civic grammar for AI rights*](https://www.science.org/doi/10.1126/science.aeh7153){target=_blank} (Science, 2026) that the Blueprint drew its name from the first ten amendments to the U.S. Constitution, but in structural terms resembles a different founding document: the **Declaration of Independence**.
+Nelson argues that the Blueprint drew its name from the first ten amendments to the U.S. Constitution, but in structural terms resembles a different founding document: the **Declaration of Independence**.
 
 > "Unlike the Bill of Rights, the Blueprint does not establish courts or enforcement mechanisms. It does not create procedures for redress. It declares. It states principles and claims rights against a concentration of power that most Americans cannot meaningfully constrain through existing institutions or processes."
 
 The five principles, Nelson argues, are statements of values — "social expectations, stated in the vocabulary Americans reach for when they want to contest power: Patients' Bill of Rights, Consumer Bill of Rights, Tenants' Bill of Rights, Workers' Bill of Rights, Taxpayers' Bill of Rights." The Blueprint extended that civic grammar to algorithmic systems.
 
-Nelson distinguishes the public Blueprint from **corporate "AI constitutions"** — internal training and alignment specifications written by AI companies for their own models. Anthropic's *Claude Constitution* is the canonical example. These corporate documents are not negotiated with the publics affected by AI deployments, can be revised by company fiat, and recent versions have quietly removed references to international human rights agreements. The deeper question, Nelson asks, is *who gets to author the foundational documents that govern AI* — companies, or publics?
+### "Civic grammar" and the diffusion of rights claims
 
-A third category emerged in May 2026 with Pope Leo XIV's first encyclical [*Magnifica Humanitas*](https://www.vatican.va/content/leo-xiv/en/encyclicals/documents/20260515-magnifica-humanitas.html){target=_blank} — neither a corporate document like the *Claude Constitution* nor a public-policy document like the Blueprint, but a transnational moral institution speaking on behalf of 1.4 billion Catholics (and addressed beyond them, to "every person of goodwill") claiming authority against both the technocratic paradigm and the states that abdicate the field. It is a *declaration* in Nelson's sense — moral vocabulary without courts or enforcement — and its principles (human dignity, common good, subsidiarity, solidarity, social justice) converge on the same protections [UNESCO](#table-2-international-ai-agreements), [OECD](#table-2-international-ai-agreements), the [EU AI Act](#table-2-international-ai-agreements), and the [Framework Convention](#table-3-declarations-on-ai) already enumerate: non-discrimination, transparency, human oversight, and recourse. What it uniquely adds is the extension of the historic Catholic doctrine of the *universal destination of goods* to "patents, algorithms, digital platforms, technological infrastructure and data," together with a named critique of frontier-lab concentration; what it does not provide is the operational machinery — algorithmic impact assessments, audit protocols, model evaluations — that Nelson identifies as the harder labor of translating grammar into enforcement.
+Nelson describes what has emerged as a **"civic grammar"**: a shared vocabulary of rights claims (non-discrimination, transparency, data privacy, notice, human alternatives) that publics can extend to new institutions and new harms, and that "has been traveling across jurisdictions, partisan lines, and institutional contexts."
 
-For the philosophical framing in depth (T. H. Marshall's social-citizenship framework, the diffusion mechanism, the limits of rights talk) and the full treatment of *Magnifica Humanitas*, see [AI Constitutions and Bills of Rights](ethics.md#ai-constitutions-and-bills-of-rights) and [Catholic social teaching](ethics.md#catholic-social-teaching-magnifica-humanitas-pope-leo-xiv-2026) in the Ethics lesson.
+This pattern reflects what sociologists David Strang and John Meyer call **institutional diffusion** among *weakly related actors* — a conceptual rather than relational mechanism by which abstract typologies become "a strategy for making sense of the world." Connecticut Democrats, Oklahoma Republicans, Florida's Republican governor, and a national student-advocacy network can adopt the same vocabulary without coordinating, because all are responding to the same structural condition: AI reshaping people's lives without their consultation.
 
 ### The Blueprint's "second life": cross-partisan diffusion
 
@@ -157,15 +168,45 @@ Although rescinded at the federal level, the Blueprint, in Nelson's words, "has 
 - **Florida (2025):** Republican Governor Ron DeSantis pushed for an AI Bill of Rights through executive action and twice backed Florida Senate Bill 482, the "Artificial Intelligence Bill of Rights," which would codify several Blueprint principles into Florida law. The bill was blocked in the Florida House, where the Speaker aligned with the Trump administration's effort to prevent states from regulating AI.
 - **Student AI Bill of Rights (2026):** The National Student Legal Defense Network released a Student AI Bill of Rights.
 
-These actors did not coordinate. As Nelson puts it: "What the actors share is a vocabulary and a common perspective that AI is reshaping people's lives without their consultation." The driver of the diffusion is not relational but conceptual — what sociologists David Strang and John Meyer describe as alignment among "weakly related actors" through abstract typologies that travel "as a strategy for making sense of the world."
+As Nelson puts it: "What the actors share is a vocabulary and a common perspective that AI is reshaping people's lives without their consultation."
+
+### Marshall's social citizenship and the AI rights tier
+
+Nelson grounds the analysis in British sociologist T. H. Marshall's 1950 essay *Citizenship and Social Class*. Marshall argued that rights expand historically through successive waves of claim-making: civil rights extending to political rights, political rights extending to **social rights** — entitlements to economic security and the conditions of participation, against harms of industrial capitalism that individual civil-liberties frameworks could not address. Rights, in Marshall's account, "are never fully delivered at the moment of declaration. They are successively rearticulated by publics who attempt to hold institutions to commitments those institutions have not yet honored."
+
+The Blueprint's five principles, Nelson argues, map onto Marshall's social-rights tier. They are not classical civil liberties; they are entitlements against systems "that increasingly govern access to employment, credit, healthcare, housing, and education." The structural parallel — collective, diffuse, opaque harms that older rights frameworks address only partially — is what explains the cross-partisan convergence: "actors who disagree on nearly everything else agree that algorithmic power requires a social citizenship response."
+
+### Three imperatives for studying AI: question, object, tool
+
+Nelson's argument about AI rights builds on a broader claim she develops in [*Field Theory: AI as Social Science Question, Object & Tool*](https://www.amacad.org/publication/daedalus/field-theory-ai-social-science-question-object-tool){target=_blank} (*Daedalus*, Winter/Spring 2026): AI models, tools, and systems pose **three interrelated imperatives** for the social sciences.
+
+1. **AI as social-science question.** Renewed attention to social theories of how technology, human experience, and social order are entangled. Nelson reaches back to Weber's analysis of rationalization and W. E. B. Du Bois's study of technology and inequality, and forward to contemporary scholarship on algorithmic governance.
+2. **AI as object of inquiry.** AI systems themselves require study as social, political, and economic artifacts — not just engineering products. Their training corpora, their labor relations, their ideological commitments, and their effects on the institutions that deploy them all merit investigation in their own right.
+3. **AI as method/tool.** AI capabilities may transform — or upend — the practice of social investigation itself: large-scale text analysis, multimodal pattern detection, conversational interviewing at scale. That transformation deserves critical scrutiny rather than uncritical adoption.
+
+The capacities social science distinctively brings to all three, Nelson argues: **historicizing the apparently unprecedented**, **tracing connections across scales** (from individual experience to institutional behavior to political economy), and **centering those most affected** by technological change.
+
+This three-part framing also doubles as a useful diagnostic. When you read a piece of AI-ethics scholarship, ask which of the three imperatives it engages — that often clarifies what kind of argument is being made and what kind of counter-argument would land.
 
 ### International convergence
 
 Legal scholar Yuval Shany has surveyed international standard-setting instruments — the [EU AI Act](https://artificialintelligenceact.eu/){target=_blank}, the [Council of Europe Framework Convention on AI](https://www.coe.int/en/web/artificial-intelligence/the-framework-convention-on-artificial-intelligence){target=_blank}, the United Nations Global Digital Compact, and national legislation in South Korea and Italy — and finds they coalesce around the same protections as the Blueprint: **non-discrimination, transparency, data privacy, and human alternatives**. The pattern predates the Blueprint: the EU's General Data Protection Regulation (GDPR) established data-protection rights nearly a decade earlier. The "bill of rights" frame is American; the underlying rights-claim convergence is global.
 
+The encyclical [*Magnifica Humanitas*](#catholic-social-teaching-magnifica-humanitas-pope-leo-xiv-2026) (below) converges on the same protections from an entirely different starting point — theological anthropology rather than democratic theory or international law.
+
+### The limits of rights talk
+
+Nelson is clear-eyed about what civic grammar cannot do on its own:
+
+- **Accommodation can mimic transformation.** A vocabulary that moves easily across partisan lines may have been "drained of the political content that gives rights claims their force."
+- **Rights individualize structural problems.** Frameworks built around individual claims often fail to address the collective and systemic nature of algorithmic harms.
+- **Declaration is not delivery.** History shows "declarations of entitlement and their substantive delivery can remain decades apart, separated by the organized power of those who benefit from the status quo."
+
+Nelson's clarifying question for democratic institutions: *will they take this civic grammar seriously before the AI companies finish writing their own constitutions for us all?*
+
 ### From declaration to enforcement
 
-Nelson is direct about what civic grammar alone cannot deliver. The harder labor that remains is "translating the grammar of rights into the standards, audit protocols, and enforcement mechanisms that give those sentences force." The institutional models exist:
+The harder labor that remains is "translating the grammar of rights into the standards, audit protocols, and enforcement mechanisms that give those sentences force." The institutional models exist:
 
 - **Algorithmic impact assessments** required before AI systems are shipped.
 - **Standardized evaluation methods** for detecting algorithmic risk and harm.
@@ -176,11 +217,52 @@ What is missing, in Nelson's account, is the political will to extend existing a
 !!! info "Sources and further reading"
 
     - Alondra Nelson, [*A civic grammar for AI rights*](https://www.science.org/doi/10.1126/science.aeh7153){target=_blank}, *Science* (2026). DOI: 10.1126/science.aeh7153
+    - Alondra Nelson, [*Field Theory: AI as Social Science Question, Object & Tool*](https://www.amacad.org/publication/daedalus/field-theory-ai-social-science-question-object-tool){target=_blank}, *Daedalus* (Winter/Spring 2026)
     - Alondra Nelson, [Bluesky thread on these principles](https://bsky.app/profile/alondra.bsky.social/post/3mltfqoc7ok2y){target=_blank}
+    - T. H. Marshall, "Citizenship and Social Class" (1950)
     - [Blueprint for an AI Bill of Rights](https://bidenwhitehouse.archives.gov/ostp/ai-bill-of-rights/){target=_blank} (White House OSTP, October 2022, archived)
     - [EO 14110: Safe, Secure, and Trustworthy AI](https://www.federalregister.gov/documents/2023/11/01/2023-24283/safe-secure-and-trustworthy-development-and-use-of-artificial-intelligence){target=_blank} (Biden, October 2023, rescinded January 2025)
     - [Removing Barriers to American Leadership in AI](https://www.whitehouse.gov/presidential-actions/2025/01/removing-barriers-to-american-leadership-in-artificial-intelligence/){target=_blank} (Trump, January 2025)
     - Anthropic, [Claude's Constitution](https://www.anthropic.com/news/claudes-constitution){target=_blank}
+
+## Catholic social teaching: *Magnifica Humanitas* (Pope Leo XIV, 2026)
+
+On May 25, 2026, Pope Leo XIV released [*Magnifica Humanitas*](https://www.vatican.va/content/leo-xiv/en/encyclicals/documents/20260515-magnifica-humanitas.html){target=_blank} ("Magnificent Humanity"), his first encyclical, addressed to Catholics and "every person of goodwill." The 235-page document treats artificial intelligence as the central moral question of the age and frames AI as a new industrial revolution requiring a parallel foundational moral response.
+
+The signing date is deliberate: **May 15, 2026** is the **135th anniversary of Pope Leo XIII's *Rerum Novarum*** (1891), the foundational encyclical of modern Catholic social teaching, written to address the dignity of workers amid the 19th-century industrial revolution. Leo XIV explicitly places AI alongside that earlier disruption as a moment demanding renewed teaching.
+
+In a break with tradition, Pope Leo personally presented the encyclical at the Vatican alongside Chris Olah, co-founder of Anthropic — the first time a pontiff has presented an encyclical himself rather than delegating the task to cardinals.
+
+### Core teachings
+
+- **The centrality of the human person.** The dignity of the human person is affirmed as infinite. Human beings take precedence over AI, and any deployment of AI must be evaluated against that priority.
+- **Critique of *transhumanism*** — the project of using technology to overcome biological limits such as aging. Leo XIV rejects the framing of human finitude as a problem to be engineered away.
+- **Critique of *posthumanism*** — the philosophical position that blurs the boundaries between humans and machines, or denies the distinctiveness of human beings. The encyclical names this as an active "anti-human vision" embedded in contemporary AI development, not merely a speculative philosophical stance.
+- **Catholic social doctrine as the evaluation framework:** *dignity of the person*, *the common good*, and *justice* serve as the principles against which any AI deployment should be measured.
+- **Coverage** extends across education, the economy, unemployment, work, human trafficking, and war — the same broad social-impact terrain Catholic social teaching has historically addressed.
+
+### Calls to action
+
+- **"Disarm AI"** — withdraw AI from military applications and from purely economic interests; direct it to the common good.
+- **Stricter state and international regulation** of AI companies, not industry self-governance.
+- An explicit address to "every person of goodwill" extends the encyclical's claims of moral force beyond its Catholic audience — a move consistent with how *Laudato Si'* (2015, on climate) and the Vatican's *Antiqua et Nova* (January 2025, the Dicastery for the Doctrine of the Faith's earlier note on AI) sought ethical common ground beyond doctrinal lines.
+
+### Convergence with Nelson's civic grammar
+
+The encyclical situates AI alongside the industrial revolution as a moment requiring **foundational moral and institutional response** rather than industry self-governance. That framing converges with the [civic-grammar argument](#blueprint-for-an-ai-bill-of-rights) above — both Pope Leo and Alondra Nelson arrive at the same conclusion from very different starting points: *corporate self-governance is structurally insufficient as a source of legitimacy*.
+
+What the encyclical uniquely adds is the extension of the historic Catholic doctrine of the **universal destination of goods** to "patents, algorithms, digital platforms, technological infrastructure and data" — its strongest novel claim, and an explicit critique of frontier-lab concentration. It also introduces a **theological and humanistic vocabulary** (transhumanism, posthumanism, infinite human dignity, the common good) that may not appear in technical AI-ethics literature but increasingly shapes public reception of AI. What it does not provide is the operational machinery — algorithmic impact assessments, audit protocols, model evaluations — that Nelson identifies as the harder labor of translating grammar into enforcement.
+
+The decision to present the encyclical alongside an AI-company executive signals that the Church views the conversation as dialogic rather than purely adversarial.
+
+!!! info "Sources and further reading"
+
+    - Pope Leo XIV, [*Magnifica Humanitas*](https://www.vatican.va/content/leo-xiv/en/encyclicals/documents/20260515-magnifica-humanitas.html){target=_blank} (signed May 15, 2026; published May 25, 2026)
+    - [Vatican News announcement](https://www.vaticannews.va/en/pope/news/2026-05/pope-leo-xiv-first-encyclical-magnifica-humanitas.html){target=_blank}
+    - [CNN: Pope Leo warns of AI fueling warfare in first major theological document](https://www.cnn.com/2026/05/25/europe/pope-leo-ai-encyclical-magnifica-humanitas-intl){target=_blank}
+    - [America Magazine: Pope Leo XIV calls for AI to be 'disarmed', directed to the common good](https://www.americamagazine.org/speeches/2026/05/25/pope-leo-xiv-calls-for-ai-to-be-disarmed-directed-to-the-common-good/){target=_blank}
+    - Earlier related Catholic texts: *Antiqua et Nova* (Dicastery for the Doctrine of the Faith, January 2025, on AI); Pope Francis, [*Laudato Si'*](https://www.vatican.va/content/francesco/en/encyclicals/documents/papa-francesco_20150524_enciclica-laudato-si.html){target=_blank} (2015, on care for creation)
+    - Pope Leo XIII, [*Rerum Novarum*](https://www.vatican.va/content/leo-xiii/en/encyclicals/documents/hf_l-xiii_enc_15051891_rerum-novarum.html){target=_blank} (1891) — the 135-year predecessor referenced by the signing date
 
 ## Current Legislation
 


### PR DESCRIPTION
## Summary

Consolidates the **AI Constitutions / Bill of Rights / Nelson civic-grammar** material and the **Pope Leo XIV *Magnifica Humanitas*** encyclical treatment from `ethics.md` into `legal.md`, where the U.S. Executive Orders, international agreements, and congressional context already live. Edits both files for narrative continuity. Leaves a tight pointer in `ethics.md` so deep links continue to work via one hop.

Two places with overlapping content (the brief Magnifica paragraph and the corporate-vs-public framing were already duplicated in `legal.md`) become one.

## What moved

The previous `ethics.md` H2 sections **"AI Constitutions and Bills of Rights"** and **"Catholic social teaching: Magnifica Humanitas"** are now consolidated into `legal.md` as follows:

### `legal.md` — "Blueprint for an AI Bill of Rights" H2 (expanded)

Subsections reordered for narrative flow:

1. Timeline and status *(existing)*
2. Corporate constitutions vs. public bills of rights *(from ethics.md)*
3. Constitution vs. Bill of Rights vs. Declaration of Independence *(existing — cleaned of duplicates)*
4. "Civic grammar" and the diffusion of rights claims *(from ethics.md)*
5. The Blueprint's "second life": cross-partisan diffusion *(existing)*
6. Marshall's social citizenship and the AI rights tier *(from ethics.md)*
7. Three imperatives for studying AI: question, object, tool *(from ethics.md — Nelson's Daedalus essay)*
8. International convergence *(existing; adds a one-line forward pointer to the Magnifica section)*
9. The limits of rights talk *(from ethics.md)*
10. From declaration to enforcement *(existing)*

### `legal.md` — new sibling H2 "Catholic social teaching: *Magnifica Humanitas*"

Full encyclical treatment that was in `ethics.md` — Core teachings, Calls to action, and the "Convergence with Nelson's civic grammar" section (which now lives in the natural place for the cross-link to land).

### Cleanup along the way

- The brief Magnifica paragraph previously embedded inside "Constitution vs. Bill of Rights vs. Declaration of Independence" is gone (the new H2 below handles it); a forward pointer in the opening framing paragraph takes its place.
- The cross-link from inside that subsection to `ethics.md#ai-constitutions-and-bills-of-rights` is gone (no longer needed — the content is in this file now).
- Combined Sources callout drops a duplicate Nelson reference and gains the Daedalus essay citation.

### `ethics.md`

Two big H2s replaced with a single short H2 **"AI Constitutions, Bills of Rights, and Pope Leo XIV's encyclical"** — one framing paragraph + two anchored links into `legal.md`. ethics.md is now 90 lines (down from 167); legal.md is 482 lines (up from 392). Net wash; intent is consolidation, not slimming.

## Anchor compatibility

The previous `ethics.md` anchors — `#ai-constitutions-and-bills-of-rights` and `#catholic-social-teaching-magnifica-humanitas-pope-leo-xiv-2026` — are gone. The equivalent anchors now live in `legal.md` at the same fragment names. The pointer in `ethics.md` uses those new anchors so any external deep links continue to work via one hop.

## Test plan

- [ ] Build workflow completes on merge
- [ ] `/ethics/` shows the short "AI Constitutions…" pointer section with both cross-links resolving
- [ ] `/legal/#blueprint-for-an-ai-bill-of-rights` renders all 10 new subsections in order, with internal forward-pointer to the Magnifica section
- [ ] `/legal/#catholic-social-teaching-magnifica-humanitas-pope-leo-xiv-2026` renders the encyclical H2 with the "Convergence with Nelson's civic grammar" cross-link back up to the Blueprint section

https://claude.ai/code/session_016V7qR3rPU4vy5ogRPhib8X

---
_Generated by [Claude Code](https://claude.ai/code/session_016V7qR3rPU4vy5ogRPhib8X)_