### PR TITLE
Move KEYS slide-deck link to top of keys.md for visibility

### DIFF
--- a/docs/tutorials/keys.md
+++ b/docs/tutorials/keys.md
@@ -4,6 +4,12 @@
 
 A one-hour module for [BIO5 KEYS Research Internship](https://keys.arizona.edu/){target=_blank} students. Forty minutes of lecture on what generative AI is actually doing in life-sciences labs in 2026, followed by twenty minutes of hands-on practice on the University of Arizona's [genai.arizona.edu](https://genai.arizona.edu/){target=_blank} platform.
 
+!!! tip ":material-presentation: Slide deck for this lesson"
+
+    The full 60-minute lecture is available as a fullscreen slide deck:
+    **[Generative AI for Life Sciences — KEYS Internship](presentations/keys-internship-generative-ai.html){target=_blank}**.
+    Open in a new tab, press **F11** (Windows/Linux) or **Cmd + Ctrl + F** (macOS) for true fullscreen, and use arrow keys to navigate. See the [Presentations](presentations/overview.md) page for all decks.
+
 !!! Example "What you'll walk out with (60 min)"
 
     - A working mental model of what an LLM is doing when it answers you, and where that breaks
@@ -15,9 +21,6 @@ A one-hour module for [BIO5 KEYS Research Internship](https://keys.arizona.edu/)
 ## Who this is for
 
 KEYS interns working in BIO5-affiliated labs across bioscience, biomedical engineering, biotechnology, statistics, and computational biology. No coding background required. Some background in high-school biology helps; the specific examples will translate to whatever your lab does.
-
-!!! tip "Presenter mode"
-    The full 60-minute lecture is also available as a [slide deck](presentations/keys-internship-generative-ai.html){target=_blank} on the [Presentations](presentations/overview.md) page.
 
 ## Schedule
 


### PR DESCRIPTION
## Summary

PR #25 added a "Presenter mode" tip below the "Who this is for" section — easy to miss when readers land on `/tutorials/keys/`. This moves the slide-deck link to the very top of the page (right after the opening paragraph, before "What you'll walk out with") so it's the first thing anyone arriving at the lesson sees.

Also slightly expands the callout to include the fullscreen keyboard-shortcut hint (**F11** / **Cmd + Ctrl + F**) and a pointer to the broader [Presentations](https://tyson-swetnam.github.io/intro-gpt/tutorials/presentations/overview/) page.

The link target is unchanged: `presentations/keys-internship-generative-ai.html` (added in PR #25).

## Test plan

- [ ] Build workflow completes on merge
- [ ] [/tutorials/keys/](https://tyson-swetnam.github.io/intro-gpt/tutorials/keys/) shows the deck-link callout immediately under the opening paragraph
- [ ] The old "Presenter mode" tip below "Who this is for" is gone (no duplicate)
- [ ] Link to the deck resolves

https://claude.ai/code/session_016V7qR3rPU4vy5ogRPhib8X

---
_Generated by [Claude Code](https://claude.ai/code/session_016V7qR3rPU4vy5ogRPhib8X)_