### PR TITLE
Add workshop-pages link (tinyurl.com/phai-26) to the geospatial title slide

### DIFF
--- a/docs/tutorials/presentations/geospatial-ai-public-health.html
+++ b/docs/tutorials/presentations/geospatial-ai-public-health.html
@@ -460,6 +460,11 @@
         <h1 class="display" style="font-size: 168px;">
           Geospatial<br>Analysis,<br><span style="color: var(--ua-red-bright);">AI-Powered.</span>
         </h1>
+        <a class="mono" href="https://tinyurl.com/phai-26" target="_blank" rel="noopener"
+           style="margin-top: 44px; display: inline-flex; align-items: baseline; gap: 18px; text-decoration: none; color: var(--cream);">
+          <span class="tag">Workshop pages ↗</span>
+          <span style="font-size: 44px; font-weight: 700; letter-spacing: -0.01em;">tinyurl.com/phai-26</span>
+        </a>
       </div>
 
       <div class="title-slide-content" style="gap: 12px;">


### PR DESCRIPTION
Adds the workshop landing-page link to **slide 1 (title)** of the geospatial deck, so attendees have it in view from the start.

- A clickable callout under the title: **`Workshop pages ↗  tinyurl.com/phai-26`** → links to `https://tinyurl.com/phai-26`.
- Styled with the deck's existing `.tag` + `.mono` system (cream on the dark title slide); the URL is shown without the `https://` for legibility while the link carries the full URL. Opens in a new tab.

Single-line insertion on the title slide. Merging triggers the Pages build and publishes it.

https://claude.ai/code/session_01XBbvzd2Mmhg1s7yK63gcjf

---
_Generated by [Claude Code](https://claude.ai/code/session_01XBbvzd2Mmhg1s7yK63gcjf)_