### PR TITLE
Rename "AI Fluency" → "AI Literacy" in the Prompt Engineering decks

### DIFF
--- a/docs/tutorials/presentations/prompt-engineering-basics.html
+++ b/docs/tutorials/presentations/prompt-engineering-basics.html
@@ -485,7 +485,7 @@
       </div>
 
       <div class="title-slide-content" style="margin-top: 60px;">
-        <div class="tag" style="font-size: 26px;">AI Fluency Track · Deep Dive</div>
+        <div class="tag" style="font-size: 26px;">AI Literacy Track · Deep Dive</div>
         <h1 class="display" style="font-size: 168px;">
           Prompt<br>Engineering,<br><span style="color: var(--ua-red-bright);">on purpose.</span>
         </h1>
@@ -513,7 +513,7 @@
   <section data-screen-label="02 Outcome">
     <div class="slide">
       <div class="deck-header">
-        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Literacy</span></div>
         <div>02 / Outcome</div>
       </div>
 
@@ -547,7 +547,7 @@
   <section data-screen-label="03 Part 1 Divider" class="slide-dark">
     <div class="section-slide">
       <div class="deck-header">
-        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Literacy</span></div>
         <div>Part 01 · Mental Model</div>
       </div>
       <div>
@@ -571,7 +571,7 @@
   <section data-screen-label="04 Pipeline">
     <div class="slide">
       <div class="deck-header">
-        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Literacy</span></div>
         <div>04 / The Pipeline</div>
       </div>
 
@@ -624,7 +624,7 @@
   <section data-screen-label="05 Capability Table" class="slide-paper">
     <div class="slide slide-paper">
       <div class="deck-header">
-        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Literacy</span></div>
         <div>05 / Tooling 2026</div>
       </div>
 
@@ -704,7 +704,7 @@
   <section data-screen-label="06 Good Better Best">
     <div class="slide">
       <div class="deck-header">
-        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Literacy</span></div>
         <div>06 / Anatomy</div>
       </div>
 
@@ -761,7 +761,7 @@ Format as a list."</span></pre>
   <section data-screen-label="07 Part 2 Divider" class="slide-red">
     <div class="section-slide">
       <div class="deck-header">
-        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Literacy</span></div>
         <div>Part 02 · The CRAFT Framework</div>
       </div>
       <div>
@@ -785,7 +785,7 @@ Format as a list."</span></pre>
   <section data-screen-label="08 CRAFT Context">
     <div class="slide">
       <div class="deck-header">
-        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Literacy</span></div>
         <div>08 / CRAFT · 01</div>
       </div>
 
@@ -820,7 +820,7 @@ Format as a list."</span></pre>
   <section data-screen-label="09 CRAFT Role" class="slide-paper">
     <div class="slide slide-paper">
       <div class="deck-header">
-        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Literacy</span></div>
         <div>09 / CRAFT · 02</div>
       </div>
 
@@ -855,7 +855,7 @@ Format as a list."</span></pre>
   <section data-screen-label="10 CRAFT Action">
     <div class="slide">
       <div class="deck-header">
-        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Literacy</span></div>
         <div>10 / CRAFT · 03</div>
       </div>
 
@@ -890,7 +890,7 @@ Format as a list."</span></pre>
   <section data-screen-label="11 CRAFT Format" class="slide-paper">
     <div class="slide slide-paper">
       <div class="deck-header">
-        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Literacy</span></div>
         <div>11 / CRAFT · 04</div>
       </div>
 
@@ -925,7 +925,7 @@ Format as a list."</span></pre>
   <section data-screen-label="12 CRAFT Tone">
     <div class="slide">
       <div class="deck-header">
-        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Literacy</span></div>
         <div>12 / CRAFT · 05</div>
       </div>
 
@@ -960,7 +960,7 @@ Format as a list."</span></pre>
   <section data-screen-label="13 CRAFT Example" class="slide-dark">
     <div class="slide slide-dark">
       <div class="deck-header">
-        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Literacy</span></div>
         <div>13 / CRAFT in Full</div>
       </div>
 
@@ -1009,7 +1009,7 @@ Format as a list."</span></pre>
   <section data-screen-label="14 Part 3 Divider" class="slide-dark">
     <div class="section-slide">
       <div class="deck-header">
-        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Literacy</span></div>
         <div>Part 03 · Advanced Techniques</div>
       </div>
       <div>
@@ -1033,7 +1033,7 @@ Format as a list."</span></pre>
   <section data-screen-label="15 Custom Instructions">
     <div class="slide">
       <div class="deck-header">
-        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Literacy</span></div>
         <div>15 / Technique 01</div>
       </div>
 
@@ -1083,7 +1083,7 @@ in all code.
   <section data-screen-label="16 Few-Shot" class="slide-paper">
     <div class="slide slide-paper">
       <div class="deck-header">
-        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Literacy</span></div>
         <div>16 / Technique 02</div>
       </div>
 
@@ -1130,7 +1130,7 @@ Now classify these:
   <section data-screen-label="17 Chaining">
     <div class="slide">
       <div class="deck-header">
-        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Literacy</span></div>
         <div>17 / Technique 03</div>
       </div>
 
@@ -1178,7 +1178,7 @@ Now classify these:
   <section data-screen-label="18 Multimodal Search" class="slide-paper">
     <div class="slide slide-paper">
       <div class="deck-header">
-        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Literacy</span></div>
         <div>18 / Techniques 04 + 05</div>
       </div>
 
@@ -1227,7 +1227,7 @@ Summarize the top 5 with links.</pre>
   <section data-screen-label="19 Part 4 Divider" class="slide-red">
     <div class="section-slide">
       <div class="deck-header">
-        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Literacy</span></div>
         <div>Part 04 · Common Pitfalls</div>
       </div>
       <div>
@@ -1251,7 +1251,7 @@ Summarize the top 5 with links.</pre>
   <section data-screen-label="20 Pitfalls 1-2">
     <div class="slide">
       <div class="deck-header">
-        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Literacy</span></div>
         <div>20 / Pitfalls 01–02</div>
       </div>
 
@@ -1300,7 +1300,7 @@ Summarize the top 5 with links.</pre>
   <section data-screen-label="21 Pitfalls 3-4" class="slide-paper">
     <div class="slide slide-paper">
       <div class="deck-header">
-        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Literacy</span></div>
         <div>21 / Pitfalls 03–04</div>
       </div>
 
@@ -1349,7 +1349,7 @@ Summarize the top 5 with links.</pre>
   <section data-screen-label="22 Checklist">
     <div class="slide">
       <div class="deck-header">
-        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Literacy</span></div>
         <div>22 / Quick Reference</div>
       </div>
 
@@ -1408,7 +1408,7 @@ Summarize the top 5 with links.</pre>
   <section data-screen-label="23 Resources" class="slide-paper">
     <div class="slide slide-paper">
       <div class="deck-header">
-        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Literacy</span></div>
         <div>23 / Resources</div>
       </div>
 
@@ -1457,7 +1457,7 @@ Summarize the top 5 with links.</pre>
       <div class="title-slide">
         <div class="grid-bg"></div>
         <div class="deck-header">
-          <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+          <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Literacy</span></div>
           <div>End · Q&amp;A</div>
         </div>
 

--- a/docs/tutorials/presentations/prompt-engineering-deep-dive.html
+++ b/docs/tutorials/presentations/prompt-engineering-deep-dive.html
@@ -642,7 +642,7 @@
       </div>
 
       <div class="title-slide-content" style="margin-top: 40px;">
-        <div class="tag" style="font-size: 26px;">AI Fluency Track · Deep Dive</div>
+        <div class="tag" style="font-size: 26px;">AI Literacy Track · Deep Dive</div>
         <h1 class="display" style="font-size: 156px;">
           Agentic<br>Engineering<span style="color: var(--ua-red-bright);">.</span>
         </h1>
@@ -674,7 +674,7 @@
   <section data-screen-label="02 Mental Shift">
     <div class="slide">
       <div class="deck-header">
-        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Literacy</span></div>
         <div>02 / The Shift</div>
       </div>
 
@@ -712,7 +712,7 @@
   <section data-screen-label="03 Outcome" class="slide-paper">
     <div class="slide slide-paper">
       <div class="deck-header">
-        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Literacy</span></div>
         <div>03 / Outcome</div>
       </div>
 
@@ -760,7 +760,7 @@
   <section data-screen-label="04 Part 1 Divider" class="slide-dark">
     <div class="section-slide">
       <div class="deck-header">
-        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Literacy</span></div>
         <div>Part 01 · Vibe Coding</div>
       </div>
       <div>
@@ -784,7 +784,7 @@
   <section data-screen-label="05 Karpathy" class="slide-paper">
     <div class="slide slide-paper">
       <div class="deck-header">
-        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Literacy</span></div>
         <div>05 / Origin</div>
       </div>
 
@@ -823,7 +823,7 @@
   <section data-screen-label="06 Four Surfaces">
     <div class="slide">
       <div class="deck-header">
-        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Literacy</span></div>
         <div>06 / Surfaces</div>
       </div>
 
@@ -900,7 +900,7 @@
   <section data-screen-label="07 Tool Decision" class="slide-paper">
     <div class="slide slide-paper">
       <div class="deck-header">
-        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Literacy</span></div>
         <div>07 / Choosing</div>
       </div>
 
@@ -967,7 +967,7 @@
   <section data-screen-label="08 Part 2 Divider" class="slide-red">
     <div class="section-slide">
       <div class="deck-header">
-        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Literacy</span></div>
         <div>Part 02 · Local Filesystems</div>
       </div>
       <div>
@@ -991,7 +991,7 @@
   <section data-screen-label="09 Agent Capabilities">
     <div class="slide">
       <div class="deck-header">
-        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Literacy</span></div>
         <div>09 / Capabilities</div>
       </div>
 
@@ -1039,7 +1039,7 @@
   <section data-screen-label="10 Practices" class="slide-paper">
     <div class="slide slide-paper">
       <div class="deck-header">
-        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Literacy</span></div>
         <div>10 / Practices</div>
       </div>
 
@@ -1090,7 +1090,7 @@
   <section data-screen-label="11 Part 3 Divider" class="slide-dark">
     <div class="section-slide">
       <div class="deck-header">
-        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Literacy</span></div>
         <div>Part 03 · Model Context Protocol</div>
       </div>
       <div>
@@ -1114,7 +1114,7 @@
   <section data-screen-label="12 MCP Concept">
     <div class="slide">
       <div class="deck-header">
-        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Literacy</span></div>
         <div>12 / MCP · What</div>
       </div>
 
@@ -1165,7 +1165,7 @@
   <section data-screen-label="13 MCP Architecture" class="slide-paper">
     <div class="slide slide-paper">
       <div class="deck-header">
-        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Literacy</span></div>
         <div>13 / MCP · How</div>
       </div>
 
@@ -1228,7 +1228,7 @@
   <section data-screen-label="14 MCP Config">
     <div class="slide">
       <div class="deck-header">
-        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Literacy</span></div>
         <div>14 / MCP · Config</div>
       </div>
 
@@ -1279,7 +1279,7 @@
   <section data-screen-label="15 Part 4 Divider" class="slide-dark">
     <div class="section-slide">
       <div class="deck-header">
-        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Literacy</span></div>
         <div>Part 04 · AI Sandboxes</div>
       </div>
       <div>
@@ -1303,7 +1303,7 @@
   <section data-screen-label="16 Sandbox Tiers">
     <div class="slide">
       <div class="deck-header">
-        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Literacy</span></div>
         <div>16 / Sandboxes</div>
       </div>
 
@@ -1364,7 +1364,7 @@
   <section data-screen-label="17 Agentic Loop" class="slide-paper">
     <div class="slide slide-paper">
       <div class="deck-header">
-        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Literacy</span></div>
         <div>17 / The Loop</div>
       </div>
 
@@ -1422,7 +1422,7 @@
   <section data-screen-label="18 Part 5 Divider" class="slide-red">
     <div class="section-slide">
       <div class="deck-header">
-        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Literacy</span></div>
         <div>Part 05 · Agentic Research</div>
       </div>
       <div>
@@ -1446,7 +1446,7 @@
   <section data-screen-label="19 Lit Review">
     <div class="slide">
       <div class="deck-header">
-        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Literacy</span></div>
         <div>19 / Literature</div>
       </div>
 
@@ -1499,7 +1499,7 @@
   <section data-screen-label="20 Hypothesis Roles" class="slide-paper">
     <div class="slide slide-paper">
       <div class="deck-header">
-        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Literacy</span></div>
         <div>20 / Hypothesis</div>
       </div>
 
@@ -1551,7 +1551,7 @@ equations in LaTeX or MathJax.</pre>
   <section data-screen-label="21 Code Execution">
     <div class="slide">
       <div class="deck-header">
-        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Literacy</span></div>
         <div>21 / Code Execution</div>
       </div>
 
@@ -1619,7 +1619,7 @@ equations in LaTeX or MathJax.</pre>
   <section data-screen-label="22 Safety Stack" class="slide-paper">
     <div class="slide slide-paper">
       <div class="deck-header">
-        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Literacy</span></div>
         <div>22 / Safety</div>
       </div>
 
@@ -1672,7 +1672,7 @@ equations in LaTeX or MathJax.</pre>
   <section data-screen-label="23 Resources">
     <div class="slide">
       <div class="deck-header">
-        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+        <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Literacy</span></div>
         <div>23 / Resources</div>
       </div>
 
@@ -1725,7 +1725,7 @@ equations in LaTeX or MathJax.</pre>
       <div class="title-slide">
         <div class="grid-bg"></div>
         <div class="deck-header">
-          <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Fluency</span></div>
+          <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI Literacy</span></div>
           <div>End · Q&amp;A</div>
         </div>
 


### PR DESCRIPTION
Renames the track from **"AI Fluency" → "AI Literacy"** across both Prompt Engineering decks (the two you linked):

- `prompt-engineering-basics.html` — 24 occurrences
- `prompt-engineering-deep-dive.html` — 24 occurrences

In each, that's the recurring `PH&AI · AI Fluency` header lockup (×23) and the `AI Fluency Track · Deep Dive` title tag (×1). Pure text rename, no markup changes.

**Deliberately left out of this PR:**
- The **geospatial deck** also uses this track name (`AI Fluency`, 27×) — not in the two URLs you gave, so I left it. Happy to add it here (or separately) for consistency — see my note.
- `docs/tutoring.md` — its "AI Fluency" refers to Anthropic's actual **"Claude for You: AI Fluency Framework"** (a product name), so it should stay.

Merging triggers the Pages build and publishes both decks.

https://claude.ai/code/session_01XBbvzd2Mmhg1s7yK63gcjf

---
_Generated by [Claude Code](https://claude.ai/code/session_01XBbvzd2Mmhg1s7yK63gcjf)_