### PR TITLE
legal.md: add the 2026 Mississippi "both sides used AI" sanctions anecdote

### DIFF
--- a/docs/legal.md
+++ b/docs/legal.md
@@ -387,7 +387,9 @@ Current AI models are overwhelmingly based on European and North American histor
     
 Negative consequences of GPTs explosion into the public space are its mis-use as well as its adoption for illegal activity. 
     
-* [A lawyer submits a legal brief written by ChatGPT and is caught](https://www.nytimes.com/2023/05/27/nyregion/avianca-airline-lawsuit-chatgpt.html){target=_blank}
+* [A lawyer submits a legal brief written by ChatGPT and is caught](https://www.nytimes.com/2023/05/27/nyregion/avianca-airline-lawsuit-chatgpt.html){target=_blank} (2023)
+
+* By 2026 the problem had escalated from one embarrassed attorney to entire cases collapsing: a senior federal judge in Mississippi, [Sharion Aycock, sanctioned **all four** lawyers in an Aberdeen fee dispute after catching **both sides** independently filing AI-generated briefs full of fabricated citations and bogus quotations](https://www.nytimes.com/2026/06/09/us/ai-lawyers-sanctioned-mississippi.html){target=_blank}. She paused the trial, disqualified every attorney, barred the two who admitted using AI from her court for two years, and fined them between \$1,000 and \$3,500 — one of the strongest judicial rebukes of courtroom AI misuse to date.
 
 * [Prompt Injection Attacks](https://www.wired.com/story/chatgpt-prompt-injection-attack-security/){target=_blank}
 


### PR DESCRIPTION
Adds a current (June 2026) anecdote to the **Recent Controversy** misuse list in `legal.md`, placed right after the 2023 Avianca/ChatGPT example as its escalation.

**The story:** Senior U.S. District Judge **Sharion Aycock** (N.D. Mississippi) sanctioned **all four** attorneys in an Aberdeen fee dispute after finding that **both sides had independently** filed AI-generated briefs with fabricated citations and bogus quotations — pausing the trial, disqualifying every lawyer, barring the two who admitted to AI use from her court for two years, and fining them \$1,000–\$3,500. It's a striking teaching example because *both* sides got caught.

Notes:
- Cites the NYT article you linked. (NYT can't be machine-fetched, so I corroborated the specifics — judge, court, sanctions, fines — against Bloomberg Law, Gizmodo, JD Journal, and Epoch Times before writing.)
- Dollar amounts are backslash-escaped (`\$`) because this site has `arithmatex generic = true`, where bare `$…$` renders as math.
- Tagged the existing Avianca link "(2023)" for the timeline contrast.

Single-paragraph addition. Merging triggers the Pages build.

https://claude.ai/code/session_01XBbvzd2Mmhg1s7yK63gcjf

---
_Generated by [Claude Code](https://claude.ai/code/session_01XBbvzd2Mmhg1s7yK63gcjf)_