### PR TITLE
Add Environmental & Health Impacts lesson + Bregman "AI denial" admonition

### DIFF
--- a/docs/environment.md
+++ b/docs/environment.md
@@ -1,0 +1,131 @@
+# Environmental & Health Impacts of AI
+
+<a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.
+
+Every prompt has a physical footprint. The chatbots, copilots, and image generators that feel weightless on screen run on warehouse-scale **data centers** — buildings packed with power-hungry chips that have to be manufactured, powered, and cooled around the clock. As the AI build-out accelerates, the bill is coming due in two currencies: the **natural environment** (electricity, water, land, and materials) and **human health** (the air pollution, heat, and disruption borne by the communities living next to the infrastructure).
+
+This lesson surveys both — and the trade-offs every AI user and institution should weigh.
+
+!!! Abstract "The short version"
+
+    - AI is driving the **fastest surge in electricity demand in a generation**: global data-center power use is projected to **more than double to ~945 TWh by 2030** — roughly **3% of the world's electricity**, about what Japan consumes today.
+    - Meeting that demand is **delaying the retirement of coal and gas plants**, spurring a wave of new gas turbines, and reopening nuclear reactors — while Big Tech's own emissions **rise** despite net-zero pledges.
+    - Data centers **consume water** — directly for cooling and indirectly through the power plants feeding them — increasingly in **drought-stressed regions**.
+    - The pollution carries a measurable **human toll**: U.S. data-center air pollution is projected to cause on the order of **1,300 premature deaths and ~\$20 billion in health damages per year by 2030**, concentrated in the low-income and minority communities sited next to the turbines.
+
+## A footprint you can't see on screen
+
+The mental model that AI is "just software" hides a heavy industrial reality. Behind every model are three physical demands that grow with use:
+
+- **Compute** — racks of GPUs/TPUs that must be **manufactured** (mining, chip fabrication) and eventually **discarded**.
+- **Energy** — electricity to run the chips, around the clock, at very high power density.
+- **Cooling** — water and/or still more electricity to carry away the heat those chips produce.
+
+Training a frontier model is expensive, but the larger and growing cost is **inference** — answering billions of everyday queries. A single AI-generated answer can use [several times the energy of a traditional web search](https://www.iea.org/reports/energy-and-ai){target=_blank}, and that small per-query cost multiplies across billions of prompts a day.
+
+## Energy demand and the grid
+
+### How much electricity?
+
+The International Energy Agency's [*Energy and AI*](https://www.iea.org/reports/energy-and-ai){target=_blank} report projects that global **data-center electricity use will reach about 945 TWh by 2030** — roughly **3% of all electricity worldwide** and more than double 2024 levels.
+
+- Data-center demand grows about **15% per year** through 2030 — **four times faster** than total electricity demand from every other sector combined.
+- The growth is **AI-specific**: electricity for "accelerated servers" (the GPU clusters that run AI) climbs ~**30% per year**.
+- In the **United States** alone, data centers add about **240 TWh** by 2030 (a **130% increase**).
+- In the IEA's higher-growth scenario, global data-center demand exceeds **1,700 TWh by 2035** (~4.4% of world electricity).
+
+### Where that power comes from — and who pays
+
+A demand spike this fast outruns the clean-energy build-out, with knock-on effects:
+
+- **Fossil lock-in.** Utilities are **postponing the retirement of coal and gas plants** and fast-tracking new **gas turbines** to serve data-center load — slowing, not speeding, the energy transition.
+- **A nuclear scramble.** Tech firms are signing deals to reopen reactors (Microsoft and Constellation's **Three Mile Island** restart) and to build **small modular reactors** (Google–Kairos, Amazon, Meta) — but new nuclear arrives slowly and won't cover near-term demand.
+- **Rising emissions.** Despite net-zero pledges, the largest AI firms report **growing** greenhouse-gas emissions — Google's were up roughly **48%** and Microsoft's nearly **30%** against their baselines as the build-out accelerated.
+- **Cost-shifting onto households.** Grid upgrades and generating capacity to serve hyperscale campuses can **raise electricity bills for ordinary ratepayers**, who effectively subsidize the build-out.
+
+!!! Warning "The efficiency paradox"
+    Chips and data centers keep getting more efficient *per computation* — but demand is growing faster than efficiency, so **total** energy use keeps climbing. The savings are spent on **doing much more AI**, not on using less power: a classic [Jevons paradox](https://en.wikipedia.org/wiki/Jevons_paradox){target=_blank}.
+
+## Impacts on the natural environment
+
+### Water
+
+Data centers are **thirsty**. They consume fresh water two ways: **directly**, through evaporative cooling that boils off water to shed heat, and **indirectly**, through the water-cooled power plants that supply their electricity (often **80% or more** of the total). The UC Riverside study [*Making AI Less "Thirsty"*](https://arxiv.org/abs/2304.03271){target=_blank} estimated that:
+
+- A short ChatGPT exchange of **10–50 questions** can consume roughly **500 ml of water** (a 16-oz bottle) once cooling and the regional power mix are counted.
+- Training **GPT-3** in U.S. data centers consumed on the order of **5.4 million liters** of water.
+
+The deeper problem is **where** this happens: hyperscale campuses are frequently sited in **hot, water-stressed regions** (the U.S. Southwest, Chile, Spain), putting them in direct competition with farms and households for scarce fresh water.
+
+### Land, materials, and electronic waste
+
+- **Construction & land.** Each campus is a large industrial footprint — concrete, steel, and graded land (with embodied carbon and habitat loss) plus substations and transmission corridors.
+- **Materials.** The chips depend on **mined** silicon, copper, and rare-earth elements and on water- and energy-intensive **semiconductor fabrication**.
+- **E-waste.** AI hardware is replaced on a fast cycle. A 2024 *Nature Computational Science* analysis, [*Modeling the increase of electronic waste due to generative AI*](https://www.nature.com/articles/s43588-024-00726-0){target=_blank}, estimated generative AI could add a cumulative **1.2–5.0 million tonnes of e-waste between 2020 and 2030** — much of it laden with lead and other toxics — though circular-economy strategies could cut that by **16–86%**.
+
+## Impacts on human health
+
+The costs above are not abstract — they land on **human bodies**, and not evenly.
+
+### Air pollution and its body count
+
+To meet deadlines and bridge grid shortfalls, data centers lean on **on-site fossil generation**: diesel **backup generators** and, increasingly, **gas turbines**. These emit fine particulate matter (**PM2.5**), nitrogen oxides (**NOₓ**), and sulfur dioxide — pollutants linked to asthma, heart disease, lung cancer, and premature death. The 2024 UC Riverside–Caltech report [*The Unpaid Toll*](https://arxiv.org/abs/2412.06288){target=_blank} quantified the U.S. health burden using EPA methods:
+
+- Approximately **1,300 premature deaths per year by 2030**.
+- About **600,000 asthma-symptom cases**.
+- Total public-health costs approaching **~\$20 billion per year** — a hidden subsidy paid in clinic visits, missed school, and lost lives.
+
+### Environmental justice: who lives next to the turbines
+
+Pollution and water stress are **disproportionately sited** in low-income communities and communities of color — the same environmental-justice pattern as older heavy industry.
+
+!!! Danger "Case study — xAI's *Colossus*, Memphis"
+
+    Elon Musk's **xAI** powered its **Colossus** supercomputer in **Boxtown**, a historically Black neighborhood of South Memphis, by running a fleet of **methane gas turbines** — for a time **without the required Clean Air Act permits**. As the build-out expanded toward a second site in **Southaven, Mississippi**, residents and regulators counted **dozens of unpermitted turbines** capable of emitting on the order of **2,500 tons of NOₓ a year** — likely the **single largest industrial source of smog-forming pollution in greater Memphis**, an area that already fails federal smog standards.
+
+    In 2026 the **NAACP**, represented by [**Earthjustice**](https://earthjustice.org/case/xai-illegal-gas-power-plant-data-center-colossus){target=_blank} and the [Southern Environmental Law Center](https://www.selc.org/news/xai-built-an-illegal-power-plant-to-power-its-data-center/){target=_blank}, sued xAI for Clean Air Act violations — seeking to halt the unpermitted turbines and force best-available pollution controls. It is among the first major legal tests of who bears the health cost of the AI build-out.
+
+### Heat, noise, and local stress
+
+Beyond air and water, neighbors of a large data center contend with the **constant low-frequency hum** of cooling systems and generators, **waste heat**, and **competition for local water and grid capacity** — quality-of-life and health stressors that rarely appear in a model's "cost."
+
+## What responsible use looks like
+
+The footprint is real, but it is not a reason to abandon AI — it is a reason to use it **deliberately** and to demand accountability.
+
+- **Right-size the model.** Use the **smallest model that does the job**; reserve frontier models for tasks that need them. Don't fire off a giant model for a one-line answer.
+- **Batch and reuse.** Cache and reuse results; avoid needless re-runs and "let me regenerate that ten more times" habits.
+- **Favor accountable providers.** Prefer vendors that **disclose** energy, water, and carbon per workload and that **match clean energy** on the same grid and hour — not just buy distant offsets.
+- **Ask where the campus is.** Support siting that uses **recycled/non-potable water and closed-loop cooling**, avoids water-stressed basins, and does not concentrate pollution in already-overburdened communities.
+- **Push for transparency and regulation.** Disclosure standards, honest accounting, and real permitting — rather than the [fast-tracked federal permitting carve-outs for data centers](legal.md#current-legislation) — are what turn "use a smaller model" from a personal gesture into structural change.
+
+!!! Question "Is 'use a smaller model when you can' enough?"
+    A recurring debate in AI ethics: is individual restraint a meaningful environmental ethic, or a **personal-virtue dodge** that lets the system off the hook — the AI equivalent of "use less plastic"? Both can be true. Personal choices matter at the margin; **disclosure, clean-energy siting, and enforceable permits** are what move the needle at scale.
+
+## Further reading
+
+- [IEA — *Energy and AI*](https://www.iea.org/reports/energy-and-ai){target=_blank} — the authoritative global outlook on AI electricity demand.
+- [*The Unpaid Toll*: Quantifying the Public Health Impact of Data Centers](https://arxiv.org/abs/2412.06288){target=_blank} (UC Riverside & Caltech, 2024).
+- [*Making AI Less "Thirsty"*](https://arxiv.org/abs/2304.03271){target=_blank} — AI's water footprint (UC Riverside, 2023).
+- [*Modeling the increase of electronic waste due to generative AI*](https://www.nature.com/articles/s43588-024-00726-0){target=_blank} (*Nature Computational Science*, 2024).
+- [Earthjustice — NAACP v. xAI](https://earthjustice.org/case/xai-illegal-gas-power-plant-data-center-colossus){target=_blank} — the Memphis Clean Air Act case.
+
+## Assessment
+
+??? Question "Name the two ways a data center consumes water, and which is usually larger."
+    ??? Success "On-site cooling vs. the power supply"
+        **Direct** (on-site evaporative cooling) and **indirect** (water used by the power plants generating its electricity). The **indirect** share is usually larger — often **80% or more** of total water use — so a data center's water footprint depends heavily on how clean and water-efficient its **grid** is.
+
+??? Question "Why is the health burden of AI data centers an environmental-justice issue, not just an environmental one?"
+    ??? Success
+        The **gas turbines and diesel generators** that bridge grid shortfalls emit PM2.5 and NOₓ, and these facilities are **disproportionately sited in low-income communities and communities of color** (e.g., xAI's turbines in Boxtown, South Memphis). Those neighbors breathe the pollution and bear the asthma, heart-disease, and premature-death costs, while the benefits of the compute accrue elsewhere.
+
+??? Question "True or False: because chips keep getting more efficient, AI's total energy use is falling."
+    ??? Failure "False"
+        Efficiency *per computation* is improving, but **total** demand is rising faster because we keep doing far more AI — a **Jevons paradox**. The IEA projects data-center electricity use to **more than double by 2030**.
+
+## Related lessons
+
+## [:material-scale-balance: Ethical & Legal Considerations](legal.md)
+
+## [:material-brain: Ethics of AI](ethics.md)

--- a/docs/ethics.md
+++ b/docs/ethics.md
@@ -34,6 +34,8 @@ The deeper treatment of foundational governance documents for AI — corporate "
 
 ## [:simple-weightsandbiases: Bias & Discrimination](bias.md)
 
+## [:material-leaf: Environmental & Health Impacts](environment.md)
+
 
 ## Assessment
 

--- a/docs/ethics.md
+++ b/docs/ethics.md
@@ -21,6 +21,25 @@ Over the next 70 years, Artificial Intelligence persisted mainly in [the minds o
 
 As consumers of GPTs and other AI platforms, we must consider in what ways can we use AI both effectively, and ethically.
 
+## Is AI denial the new climate denial?
+
+!!! Quote ":material-bullhorn: Rutger Bregman — 'An Inconvenient Truth About AI' (2026)"
+
+    Historian **Rutger Bregman** argues that the political polarity of denial has flipped. In [a widely shared essay (and video essay)](https://rutgerbregman.substack.com/p/an-inconvenient-truth-about-ai){target=_blank}, he writes:
+
+    > Twenty years ago, climate denial was a problem of the right. Today, AI denial is a problem of the left. And the consequences could be even more disastrous.
+
+    His case, condensed:
+
+    - **The skeptics keep moving the goalposts.** The "stochastic parrot / blurry JPEG / lumbering pattern-matcher" framing (Chomsky, Bender &amp; Gebru, and others) predicted the technology would stall. Instead the same systems have passed medical-licensing exams and out-diagnosed doctors, won gold at the International Mathematical Olympiad, out-scored PhDs in their own fields, and now write **more than 90% of the code** inside leading AI labs. Judging today's models from a frustrating attempt back in 2023, he writes, is "like judging smartphones by a 2007 BlackBerry."
+    - **The build-out is historic.** He calls the AI data-center boom the largest capital project in recorded human history — "larger than the Moon Landing and the Manhattan Project combined" — and notes one leading lab's revenue scaled from roughly \$1B to \$45B annualized in fifteen months. Even where parts of it are a bubble, "bubbles build infrastructure."
+    - **The risks are civilizational.** Biosecurity (chatbots that coach on engineering pathogens), cybersecurity (frontier models that can probe power grids and water systems), and — above all — **power**. He invokes the "**Intelligence Curse**": if the machines do the work, the people who own them no longer need the rest of us as workers, soldiers, taxpayers, or voters, dissolving the "no taxation without representation" bargain on which democracy was built.
+    - **But the answer is not "shut it down."** A blanket moratorium, Bregman argues, is *the left's own version of climate denial* — refusing to engage in the hope the future goes away. He calls instead for **state capacity** (institutes that evaluate frontier models the way the FDA evaluates drugs), **international coordination** (on the model of nuclear-arms treaties), democracies that actually **build**, and a **positive vision** (basic income, shorter work weeks) so the productivity gains are not captured by a tiny ownership class.
+
+    Whatever you make of his timeline, the essay is a sharp prompt for this course: **disengagement is itself an ethical choice.** Of one lab's decision to withhold a model it judged too dangerous to release, Bregman warns — "conscience is not a policy."
+
+    *Worth weighing against this lesson's companion on the [Environmental &amp; Health Impacts](environment.md) of the very build-out Bregman urges democracies to accelerate — fast data-center permitting reads differently from the fenceline of a gas-fired turbine.*
+
 ## AI Constitutions, Bills of Rights, and Pope Leo XIV's encyclical
 
 The deeper treatment of foundational governance documents for AI — corporate "AI constitutions" like Anthropic's *Claude Constitution*; the public *Blueprint for an AI Bill of Rights*; sociologist Alondra Nelson's "civic grammar" framework, T. H. Marshall's social-citizenship argument, and the three-imperatives framework from Nelson's *Daedalus* essay; and Pope Leo XIV's May 2026 encyclical *Magnifica Humanitas* — has been consolidated into the [Ethical & Legal Considerations](legal.md) lesson, where the U.S. Executive Orders, international agreements, and congressional context already live. Two anchors:

--- a/zensical.toml
+++ b/zensical.toml
@@ -117,7 +117,8 @@ Ethics = [
     { Overview = "ethics.md" },
     { Bias = "bias.md" },
     { Legal = "legal.md" },
-    { Transparency = "transparency.md" }
+    { Transparency = "transparency.md" },
+    { Environment = "environment.md" }
 ]
 
 [[project.nav]]


### PR DESCRIPTION
Expands the **Ethics** section with a new lesson and a provocation, cross-linked to each other.

### 1. New lesson — `environment.md` (Environmental & Health Impacts of AI)
Covers AI's physical footprint end-to-end:
- **Energy & the grid** — IEA *Energy and AI*: data-center electricity ~doubling to **~945 TWh by 2030**; fossil lock-in, the nuclear scramble, rising Big-Tech emissions, ratepayer cost-shifting, the Jevons paradox.
- **Natural environment** — water (*Making AI Less "Thirsty"*), land/materials/fab, **e-waste** (*Nature Comp. Sci.*, 1.2–5.0 Mt).
- **Human health** — air-pollution body count (*The Unpaid Toll*: ~**1,300 deaths** & ~**\$20 B/yr** by 2030) and the **xAI / Memphis** environmental-justice case.
- "Responsible use" + an Assessment. Wired into the **Ethics** nav and cross-linked from `ethics.md`.

### 2. `ethics.md` — Rutger Bregman admonition
A new **"Is AI denial the new climate denial?"** section after *Using AI ethically*, summarizing Bregman's June 2026 essay *An Inconvenient Truth About AI* (denial has flipped from right-on-climate to left-on-AI; the moving goalposts; the historic build-out; biosecurity/cyber/"Intelligence Curse" power risks; and his call for **state capacity, coordination, and building** over a moratorium). It links the essay and **cross-references the new environment lesson** — Bregman champions fast data-center permitting, which reads very differently from the fenceline of a gas turbine.

Notes: every environmental claim is cited to a primary/reputable source; dollar amounts escaped for `arithmatex`; TOML nav validated; lab names in the Bregman section kept neutral.

Merging triggers the Pages build and publishes both.

https://claude.ai/code/session_01XBbvzd2Mmhg1s7yK63gcjf