### PR TITLE
ai_landscape: add the METR time-horizons capability chart

### DIFF
--- a/docs/ai_landscape.md
+++ b/docs/ai_landscape.md
@@ -51,6 +51,25 @@ This diagram traces the lineage of large language models from 2018-2023, showing
 
 ---
 
+### The Pace of Progress: AI's "Time Horizon"
+
+The clearest single picture of *how fast* capabilities are advancing comes from [METR](https://metr.org){target=_blank}, which measures the length of task — in **human** time — that an AI agent can finish on its own (at a 50% success rate). That horizon has been **doubling roughly every seven months — and, on the latest models, faster still**: from tasks a skilled person could do in seconds a few years ago to **multi-hour** tasks in 2026.
+
+**[AI's task-completion time horizon is doubling — interactive chart (AI Digest)](https://theaidigest.org/time-horizons){target=_blank}**
+
+<iframe
+    src="https://theaidigest.org/time-horizons"
+    frameborder="0"
+    width="800"
+    height="520"
+    title="METR task-completion time horizon over time — AI Digest"
+    loading="lazy"
+></iframe>
+
+On a log scale the trend is close to a straight line — steeper than the curves that defined earlier technology waves, and a major reason independent forecasters keep revising their timelines *forward* (a point Rutger Bregman presses in ["Is AI denial the new climate denial?"](ethics.md#is-ai-denial-the-new-climate-denial)). *If the embed doesn't load, open the [interactive version](https://theaidigest.org/time-horizons){target=_blank}.*
+
+---
+
 ### From Text Generation to World Simulation
 
 The evolution of generative AI has progressed through distinct phases:


### PR DESCRIPTION
Adds the **METR "time horizon" chart** (the one Bregman highlights) to `ai_landscape.md`, in a new **"The Pace of Progress: AI's 'Time Horizon'"** subsection under *Evolution of Foundation Models*.

- Embeds **AI Digest's interactive chart** (`theaidigest.org/time-horizons`) via `<iframe>` — the same pattern the page already uses for the Matt Turck MAD landscape — with a **bold link above it** and a *"if the embed doesn't load, open the interactive version"* fallback, so the content is reachable even if framing is blocked.
- Frames the metric (task length an AI agent can finish on its own, ~7-month doubling) and **cross-links** the Bregman "AI denial" section in `ethics.md`.

Note: `theaidigest.org` is blocked from automated fetching, so I couldn't pull a static image into the repo — the iframe loads in the *visitor's* browser, which isn't subject to that restriction. If you'd rather show a static PNG, drop one in `docs/assets/` and I'll swap it.

Merging triggers the Pages build.

https://claude.ai/code/session_01XBbvzd2Mmhg1s7yK63gcjf

---
_Generated by [Claude Code](https://claude.ai/code/session_01XBbvzd2Mmhg1s7yK63gcjf)_