### PR TITLE
Ethics deck polish: current water figures, open-mic framing, drop dated date refs

### DIFF
--- a/docs/tutorials/presentations/ethics-and-environmental-impact.html
+++ b/docs/tutorials/presentations/ethics-and-environmental-impact.html
@@ -843,7 +843,7 @@
     <text x="530" y="345" font-family="Manrope, sans-serif" font-size="100" font-weight="800" fill="#f7f4ee" text-anchor="middle">A</text>
     <text x="630" y="345" font-family="Manrope, sans-serif" font-size="100" font-weight="800" fill="#f7f4ee" text-anchor="start" opacity="0">.</text>
     <text x="600" y="500" font-family="Manrope, sans-serif" font-size="56" font-weight="700" fill="#f7f4ee" text-anchor="middle">AI &amp; the Earth</text>
-    <text x="600" y="560" font-family="monospace" font-size="28" letter-spacing="6" fill="#efe9dc" text-anchor="middle" opacity="0.7">UA PH&amp;AI · PANEL</text>
+    <text x="600" y="560" font-family="monospace" font-size="28" letter-spacing="6" fill="#efe9dc" text-anchor="middle" opacity="0.7">UA PH&amp;AI · OPEN MIC</text>
   </svg>
 </template>
 
@@ -889,8 +889,8 @@
     </div>
   </section>
 
-  <!-- 02 · PANEL FORMAT -->
-<section data-screen-label="02 Panel Format" class="slide-paper">
+  <!-- 02 · OPEN-MIC FORMAT -->
+<section data-screen-label="02 Open-Mic Format" class="slide-paper">
     <div class="slide slide-paper">
       <div class="deck-header">
         <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI &amp; the Earth</span></div>
@@ -1507,11 +1507,11 @@
     <div class="section-slide">
       <div class="deck-header">
         <div class="lockup"><span class="ua-block">A</span><span>PH&amp;AI · AI &amp; the Earth</span></div>
-        <div>Part 03 · Panel Discussion</div>
+        <div>Part 03 · Open Mic</div>
       </div>
       <div>
         <div class="part-num">Part 03</div>
-        <h2 class="section-title">Over to<br>the panel<span style="color: var(--ua-red-bright);">.</span></h2>
+        <h2 class="section-title">Over to<br>the room<span style="color: var(--ua-red-bright);">.</span></h2>
         <p class="section-sub">
           Seed prompts, not a script — the framing above is shared substrate, and disagreement with it is fair game. The mic is yours.
         </p>

--- a/docs/tutorials/presentations/ethics-and-environmental-impact.html
+++ b/docs/tutorials/presentations/ethics-and-environmental-impact.html
@@ -914,7 +914,7 @@
         <div class="cap-block">
           <span class="icon-letter">10′</span>
           <h5>So what?</h5>
-          <p>We tie it back to your own work — what actually changes Tuesday morning. Bring the harder question, not the safe one.</p>
+          <p>We tie it back to your own work — what actually changes in your own practice. Bring the harder question, not the safe one.</p>
         </div>
       </div>
 
@@ -1088,18 +1088,18 @@
       <div class="footprint" style="margin-top: 56px;">
         <div class="fp-card">
           <div class="label">The thirst of one model</div>
-          <h4>It drinks while it works.</h4>
+          <h4>It drinks while it trains.</h4>
           <div style="display: flex; flex-direction: column; gap: 22px; margin-top: 4px;">
             <div>
-              <div class="mono" style="font-size: 54px; font-weight: 700; color: var(--ua-red); letter-spacing: -0.02em; line-height: 1;">~700,000 L</div>
-              <p style="margin-top: 8px;">Clean freshwater evaporated on-site to train <strong style="color: var(--ink);">GPT-3</strong> in U.S. datacenters — about 5.4M L once the supply chain is counted.</p>
+              <div class="mono" style="font-size: 54px; font-weight: 700; color: var(--ua-red); letter-spacing: -0.02em; line-height: 1;">≈ 70× GPT-3</div>
+              <p style="margin-top: 8px;">GPT-3's ~700,000 L (2020) is the last training figure anyone published. <strong style="color: var(--ink);">GPT-4</strong> is estimated near 70× that — tens of millions of liters, much of it a single month's cooling draw at one Iowa cluster.</p>
             </div>
             <div>
-              <div class="mono" style="font-size: 54px; font-weight: 700; color: var(--ua-red); letter-spacing: -0.02em; line-height: 1;">~500 mL</div>
-              <p style="margin-top: 8px;">A "bottle of water" per short conversation of roughly 20–50 prompts.</p>
+              <div class="mono" style="font-size: 54px; font-weight: 700; color: var(--ua-red); letter-spacing: -0.02em; line-height: 1;">undisclosed</div>
+              <p style="margin-top: 8px;">For today's frontier models — GPT-5-class, Claude Opus 4.x — the training-water cost is <strong style="color: var(--ink);">not published at all</strong>. The footprint grows; the transparency doesn't.</p>
             </div>
           </div>
-          <p style="margin-top: auto;"><em>— Li et al., Making AI Less "Thirsty" (2023).</em></p>
+          <p style="margin-top: auto;"><em>— GPT-3: Li et al. (2023); GPT-4: estimates from reporting on Microsoft's Iowa training cluster (2023).</em></p>
         </div>
         <div class="fp-card">
           <div class="label">Where it lands · Arizona</div>
@@ -1492,7 +1492,7 @@
       </table>
 
       <p class="small" style="margin-top: 30px; max-width: 1700px; font-size: 24px;">
-        Prompt for the room: which of these has any practical effect on what a public health researcher in Arizona actually does next Tuesday?
+        Prompt for the room: which of these has any practical effect on what a public health researcher in Arizona actually does?
       </p>
 
       <div class="deck-footer">
@@ -1616,7 +1616,7 @@
         </div>
         <div class="stack-row">
           <div class="label">More · intro-gpt</div>
-          <div class="val mono" style="color: var(--ua-red); font-size: 24px;">/bias/ · /legal/ · /transparency/</div>
+          <div class="val mono" style="color: var(--ua-red); font-size: 24px;">/environment/ · /bias/ · /legal/ · /transparency/</div>
         </div>
       </div>
 


### PR DESCRIPTION
Follow-up polish to the **"What does AI cost the Earth?"** ethics deck (the reframe itself merged in #40). All changes are to `docs/tutorials/presentations/ethics-and-environmental-impact.html`.

## Changes
- **Water slide (#7) — modernize the figure.** GPT-3 (2020) was dated. The lead stat is now **≈ 70× GPT-3** (GPT-4's training water is estimated at roughly 70× GPT-3's ~700,000 L — tens of millions of liters), with GPT-3 kept as the cited reference point (Li et al. 2023). The second stat is **"undisclosed"** — the newest frontier models' training-water cost isn't published, which is itself the point and fits the deck's "secret water footprint" theme.
- **Drop dated "Tuesday" references.** It's the school's last day, so *"what changes Tuesday morning"* (slide 2) and *"what a researcher does next Tuesday"* (declarations) were reworded to remove the day reference.
- **Unify framing to open-mic.** The earlier `main` merge left a mix of "panel" and "open-mic" language; reconciled the Part 03 divider, slide-2 label, and thumbnail to open-mic throughout (there is no panel).
- **Restore the `/environment/` resources link** now that `docs/environment.md` exists.

## Verification
- 20/20 `<section>`, balanced tags (384/384 divs), lenient HTML parse clean
- No "panel" / roster / moderator references remain in the slide body
- Cited figures sourced (IEA 2025, Li et al. 2023, Patterson 2021); estimates and illustrative bars are labeled as such

_Note: per-model training-water for the very latest models (Opus 4.x, GPT-5.x) is not published anywhere, so the slide uses GPT-4 as the current credible anchor and names the disclosure gap rather than inventing a number._

https://claude.ai/code/session_01XBbvzd2Mmhg1s7yK63gcjf

---
_Generated by [Claude Code](https://claude.ai/code/session_01XBbvzd2Mmhg1s7yK63gcjf)_